### PR TITLE
Controller ID Fix

### DIFF
--- a/src/ExtensionController.cpp
+++ b/src/ExtensionController.cpp
@@ -68,17 +68,13 @@ NXC_ControllerType ExtensionController::identifyController() {
 
 	lastID = NXC_UnknownController;  // Default if no matches below
 
-	// Nunchuk ID: All 0s
-	if (controlData[0] == 0x00 && controlData[1] == 0x00 &&
-		controlData[2] == 0x00 && controlData[3] == 0x00 &&
-		controlData[4] == 0x00 && controlData[5] == 0x00) {
+	// Nunchuk ID: 0x0000
+	if (controlData[4] == 0x00 && controlData[5] == 0x00) {
 			lastID = NXC_Nunchuk;
 	}
 
-	// Classic Con. ID: 0x0101 followed by 4 0s
-	else if (controlData[0] == 0x01 && controlData[1] == 0x01 &&
-		controlData[2] == 0x00 && controlData[3] == 0x00 &&
-		controlData[4] == 0x00 && controlData[5] == 0x00) {
+	// Classic Con. ID: 0x0101
+	else if (controlData[4] == 0x01 && controlData[5] == 0x01) {
 			lastID = NXC_ClassicController;
 	}
 


### PR DESCRIPTION
This was an oversight. The last address in the virtual Wii memory space (0xFE) does not match the address register ON the device, which is 4 bytes back. So I was getting the 16-bit IDs I expected, but they were at the END of the block rather than the front. I chalked it up to a quirk, turns out I was just reading the wrong position.

I fixed the ID pointer (from 'FE' to 'FA'), and I adjusted the Nunchuk and Classic ID checks accordingly.

For reference: I'm only checking the last two bytes because those appear to be the unique identifiers. Of the six bytes requested in the ID check, the first two appear to be modifiers for the type, the center two are constant (A420), and the final two appear to be the controller's type ID. This may change as I add more controllers, but it seems to work as-expected for the controllers I have on hand.

Ironically since I'm only using the final two bytes to check for the currently supported controllers, I could have used the botched implementation in the same way. C'est la vie.