### PR TITLE
Fix debugRaw padding + reset ID on failed init

### DIFF
--- a/src/ExtensionController.cpp
+++ b/src/ExtensionController.cpp
@@ -41,6 +41,9 @@ boolean ExtensionController::connect() {
 			return update();  // Seed with initial values
 		}
 	}
+	else {
+		connectedID = NXC_NoController;  // Bad init, nothing connected
+	}
 
 	return false;
 }


### PR DESCRIPTION
Very small PR:

* Fixes the `debugRaw` padding for 0-length characters, where the print length would evaluate to 0 rather than 1 and the loop would pad 1 extra character.
* Resets `connectedID` in the case of a failed init, as init can only fail if there's an issue with the bus. 