### PR TITLE
Replaced Stream references with Print

### DIFF
--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -116,7 +116,7 @@ boolean ClassicController_Data::buttonHome() const {
 	return getControlBit(4, 3);
 }
 
-void ClassicController_Data::printDebug(Stream& stream) const {
+void ClassicController_Data::printDebug(Print& output) const {
 	const char fillCharacter = '_';
 
 	char buffer[62];
@@ -141,7 +141,7 @@ void ClassicController_Data::printDebug(Stream& stream) const {
 	char zlButtonPrint = buttonZL() ? 'L' : fillCharacter;
 	char zrButtonPrint = buttonZR() ? 'R' : fillCharacter;
 
-	stream.print("Classic ");
+	output.print("Classic ");
 	sprintf(buffer,
 		"%c%c%c%c | %c%c%c | %c%c%c%c L:(%2u, %2u) R:(%2u, %2u) | LT:%2u%c RT:%2u%c Z:%c%c",
 		dpadLPrint, dpadUPrint, dpadDPrint, dpadRPrint,
@@ -150,7 +150,7 @@ void ClassicController_Data::printDebug(Stream& stream) const {
 		leftJoyX(), leftJoyY(), rightJoyX(), rightJoyY(),
 		triggerL(), ltButtonPrint, triggerR(), rtButtonPrint,
 		zlButtonPrint, zrButtonPrint);
-	stream.println(buffer);
+	output.println(buffer);
 }
 
 }  // End "NintendoExtensionCtrl" namespace

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -63,7 +63,7 @@ namespace NintendoExtensionCtrl {
 
 		boolean buttonHome() const;
 
-		void printDebug(Stream& stream = NXC_SERIAL_DEFAULT) const;
+		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 	};
 }
 

--- a/src/controllers/DJTurntable.cpp
+++ b/src/controllers/DJTurntable.cpp
@@ -110,19 +110,19 @@ uint8_t DJTurntableController_Data::getNumTurntables() {
 	return 0;  // Just in-case
 }
 
-void DJTurntableController_Data::printDebug(Stream& stream) {
+void DJTurntableController_Data::printDebug(Print& output) {
 	const char fillCharacter = '_';
 
 	char buffer[45];
 
-	stream.print("DJ:");
+	output.print("DJ:");
 
 	if (getNumTurntables() == 0) {
-		stream.print(" No turntable found! |");
+		output.print(" No turntable found! |");
 	}
 	else if (left.connected()) {
-		printTurntable(stream, left);
-		stream.print(" |");
+		printTurntable(output, left);
+		output.print(" |");
 	}
 
 	char plusPrint = buttonPlus() ? '+' : fillCharacter;
@@ -136,16 +136,16 @@ void DJTurntableController_Data::printDebug(Stream& stream) {
 		euphoriaPrint,
 		minusPrint, plusPrint,
 		effectDial(), crossfadeSlider());
-	stream.print(buffer);
+	output.print(buffer);
 
 	if (right.connected()) {
-		stream.print(" |");
-		printTurntable(stream, right);
+		output.print(" |");
+		printTurntable(output, right);
 	}
-	stream.println();
+	output.println();
 }
 
-void DJTurntableController_Data::printTurntable(Stream& stream, TurntableExpansion &table) const {
+void DJTurntableController_Data::printTurntable(Print& output, TurntableExpansion &table) const {
 	const char fillCharacter = '_';
 
 	char idPrint = 'X';
@@ -166,7 +166,7 @@ void DJTurntableController_Data::printTurntable(Stream& stream, TurntableExpansi
 		idPrint,
 		table.turntable(),
 		greenPrint, redPrint, bluePrint);
-	stream.print(buffer);
+	output.print(buffer);
 }
 
 // Turntable Expansion Base

--- a/src/controllers/DJTurntable.h
+++ b/src/controllers/DJTurntable.h
@@ -54,7 +54,7 @@ namespace NintendoExtensionCtrl {
 		boolean buttonPlus() const;
 		boolean buttonMinus() const;
 
-		void printDebug(Stream& stream = NXC_SERIAL_DEFAULT);
+		void printDebug(Print& output = NXC_SERIAL_DEFAULT);
 
 		TurntableConfig getTurntableConfig();
 		uint8_t getNumTurntables();
@@ -108,7 +108,7 @@ namespace NintendoExtensionCtrl {
 		};
 
 	private:
-		void printTurntable(Stream& stream, TurntableExpansion &table) const;
+		void printTurntable(Print& output, TurntableExpansion &table) const;
 
 		TurntableConfig tableConfig = TurntableConfig::BaseOnly;
 	};

--- a/src/controllers/DrumController.cpp
+++ b/src/controllers/DrumController.cpp
@@ -134,12 +134,12 @@ uint8_t DrumController_Data::velocityPedal() const {
 	return velocity(VelocityID::Pedal);
 }
 
-void DrumController_Data::printDebug(Stream& stream) const {
+void DrumController_Data::printDebug(Print& output) const {
 	const char fillCharacter = '_';
 	
 	char buffer[45];
 	
-	stream.print("Drums: ");
+	output.print("Drums: ");
 
 	char redPrint = drumRed() ? 'R' : fillCharacter;
 	char bluePrint = drumBlue() ? 'B' : fillCharacter;
@@ -189,7 +189,7 @@ void DrumController_Data::printDebug(Stream& stream) const {
 		velocityPrint, velocityIDPrint,
 		minusPrint, plusPrint,
 		joyX(), joyY());
-	stream.println(buffer);
+	output.println(buffer);
 }
 
 }  // End "NintendoExtensionCtrl" namespace

--- a/src/controllers/DrumController.h
+++ b/src/controllers/DrumController.h
@@ -68,7 +68,7 @@ namespace NintendoExtensionCtrl {
 		uint8_t velocityOrange() const;
 		uint8_t velocityPedal() const;
 
-		void printDebug(Stream& stream = NXC_SERIAL_DEFAULT) const;
+		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 	private:
 		boolean validVelocityID(uint8_t idIn) const;
 	};

--- a/src/controllers/GuitarController.cpp
+++ b/src/controllers/GuitarController.cpp
@@ -111,12 +111,12 @@ boolean GuitarController_Data::supportsTouchbar() {
 	return false;
 }
 
-void GuitarController_Data::printDebug(Stream& stream) {
+void GuitarController_Data::printDebug(Print& output) {
 	const char fillCharacter = '_';
 
 	char buffer[25];
 
-	stream.print("Guitar: ");
+	output.print("Guitar: ");
 
 	// Strum + Fret Buttons
 	char strumPrint = fillCharacter;
@@ -138,7 +138,7 @@ void GuitarController_Data::printDebug(Stream& stream) {
 		strumPrint,
 		greenPrint, redPrint, yellowPrint, bluePrint, orangePrint,
 		whammyBar());
-	stream.print(buffer);
+	output.print(buffer);
 	buffer[0] = 0;
 
 	// Touchbar, if World Controller
@@ -153,7 +153,7 @@ void GuitarController_Data::printDebug(Stream& stream) {
 			"Touch:%2u - %c%c%c%c%c | ",
 			touchbar(),
 			greenPrint, redPrint, yellowPrint, bluePrint, orangePrint);
-		stream.print(buffer);
+		output.print(buffer);
 		buffer[0] = 0;
 	}
 
@@ -165,7 +165,7 @@ void GuitarController_Data::printDebug(Stream& stream) {
 		"%c%c | Joy:(%2u, %2u)",
 		minusPrint, plusPrint,
 		joyX(), joyY());
-	stream.println(buffer);
+	output.println(buffer);
 }
 
 }  // End "NintendoExtensionCtrl" namespace

--- a/src/controllers/GuitarController.h
+++ b/src/controllers/GuitarController.h
@@ -55,7 +55,7 @@ namespace NintendoExtensionCtrl {
 		boolean buttonPlus() const;
 		boolean buttonMinus() const;
 
-		void printDebug(Stream& stream = NXC_SERIAL_DEFAULT);
+		void printDebug(Print& output = NXC_SERIAL_DEFAULT);
 
 		boolean supportsTouchbar();
 

--- a/src/controllers/NESMiniController.cpp
+++ b/src/controllers/NESMiniController.cpp
@@ -24,25 +24,25 @@
 
 NESMiniController::NESMiniController(NXC_I2C_TYPE& i2cBus) : ::ClassicController(i2cBus) {}
 
-void NESMiniController::printDebug(Stream& stream) const {
+void NESMiniController::printDebug(Print& output) const {
 	const char fillCharacter = '_';
 	
-	stream.print("NES ");
+	output.print("NES ");
 
-	stream.print(dpadLeft() ? '<' : fillCharacter);
-	stream.print(dpadUp() ? '^' : fillCharacter);
-	stream.print(dpadDown() ? 'v' : fillCharacter);
-	stream.print(dpadRight() ? '>' : fillCharacter);
-	stream.print(" | ");
+	output.print(dpadLeft() ? '<' : fillCharacter);
+	output.print(dpadUp() ? '^' : fillCharacter);
+	output.print(dpadDown() ? 'v' : fillCharacter);
+	output.print(dpadRight() ? '>' : fillCharacter);
+	output.print(" | ");
 
-	buttonSelect() ? (void) stream.print("SEL") : NintendoExtensionCtrl::printRepeat(fillCharacter, 3, stream);
-	stream.print(' ');
+	buttonSelect() ? (void)output.print("SEL") : NintendoExtensionCtrl::printRepeat(fillCharacter, 3, output);
+	output.print(' ');
 
-	buttonStart() ? (void) stream.print("STR") : NintendoExtensionCtrl::printRepeat(fillCharacter, 3, stream);
-	stream.print(" | ");
+	buttonStart() ? (void)output.print("STR") : NintendoExtensionCtrl::printRepeat(fillCharacter, 3, output);
+	output.print(" | ");
 
-	stream.print(buttonB() ? 'B' : fillCharacter);
-	stream.print(buttonA() ? 'A' : fillCharacter);
+	output.print(buttonB() ? 'B' : fillCharacter);
+	output.print(buttonA() ? 'A' : fillCharacter);
 
-	stream.println();
+	output.println();
 }

--- a/src/controllers/NESMiniController.h
+++ b/src/controllers/NESMiniController.h
@@ -29,7 +29,7 @@ class NESMiniController : public ClassicController {
 public:
 	NESMiniController(NXC_I2C_TYPE& i2cBus = NXC_I2C_DEFAULT);
 	
-	void printDebug(Stream& stream=NXC_SERIAL_DEFAULT) const;
+	void printDebug(Print& output=NXC_SERIAL_DEFAULT) const;
 };
 
 #endif

--- a/src/controllers/Nunchuk.cpp
+++ b/src/controllers/Nunchuk.cpp
@@ -61,18 +61,18 @@ float Nunchuk_Data::pitchAngle() const {
 	return -atan2((float)accelY() - 511.0, (float)accelZ() - 511.0) * 180.0 / PI;
 }
 
-void Nunchuk_Data::printDebug(Stream& stream) const {
+void Nunchuk_Data::printDebug(Print& output) const {
 	char buffer[60];
 
 	char cPrint = buttonC() ? 'C' : '-';
 	char zPrint = buttonZ() ? 'Z' : '-';
 
-	stream.print("Nunchuk - ");
+	output.print("Nunchuk - ");
 	sprintf(buffer,
 		"Joy:(%3u, %3u) | Accel XYZ:(%4u, %4u, %4u) | Buttons: %c%c",
 		joyX(), joyY(), accelX(), accelY(), accelZ(), cPrint, zPrint);
 
-	stream.println(buffer);
+	output.println(buffer);
 }
 
 }  // End "NintendoExtensionCtrl" namespace

--- a/src/controllers/Nunchuk.h
+++ b/src/controllers/Nunchuk.h
@@ -43,7 +43,7 @@ namespace NintendoExtensionCtrl {
 		float rollAngle() const;  // -180.0 to 180.0
 		float pitchAngle() const;
 
-		void printDebug(Stream& stream = NXC_SERIAL_DEFAULT) const;
+		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 	};
 }
 

--- a/src/controllers/SNESMiniController.cpp
+++ b/src/controllers/SNESMiniController.cpp
@@ -24,31 +24,31 @@
 
 SNESMiniController::SNESMiniController(NXC_I2C_TYPE& i2cBus) : ::ClassicController(i2cBus) {}
 
-void SNESMiniController::printDebug(Stream& stream) const {
+void SNESMiniController::printDebug(Print& output) const {
 	const char fillCharacter = '_';
 	
-	stream.print("SNES ");
+	output.print("SNES ");
 
-	stream.print(dpadLeft() ? '<' : fillCharacter);
-	stream.print(dpadUp() ? '^' : fillCharacter);
-	stream.print(dpadDown() ? 'v' : fillCharacter);
-	stream.print(dpadRight() ? '>' : fillCharacter);
-	stream.print(" | ");
+	output.print(dpadLeft() ? '<' : fillCharacter);
+	output.print(dpadUp() ? '^' : fillCharacter);
+	output.print(dpadDown() ? 'v' : fillCharacter);
+	output.print(dpadRight() ? '>' : fillCharacter);
+	output.print(" | ");
 
-	buttonSelect() ? (void) stream.print("SEL") : NintendoExtensionCtrl::printRepeat(fillCharacter, 3, stream);
-	stream.print(' ');
+	buttonSelect() ? (void) output.print("SEL") : NintendoExtensionCtrl::printRepeat(fillCharacter, 3, output);
+	output.print(' ');
 
-	buttonStart() ? (void) stream.print("STR") : NintendoExtensionCtrl::printRepeat(fillCharacter, 3, stream);
-	stream.print(" | ");
+	buttonStart() ? (void) output.print("STR") : NintendoExtensionCtrl::printRepeat(fillCharacter, 3, output);
+	output.print(" | ");
 
-	stream.print(buttonA() ? 'A' : fillCharacter);
-	stream.print(buttonB() ? 'B' : fillCharacter);
-	stream.print(buttonX() ? 'X' : fillCharacter);
-	stream.print(buttonY() ? 'Y' : fillCharacter);
-	stream.print(" | ");
+	output.print(buttonA() ? 'A' : fillCharacter);
+	output.print(buttonB() ? 'B' : fillCharacter);
+	output.print(buttonX() ? 'X' : fillCharacter);
+	output.print(buttonY() ? 'Y' : fillCharacter);
+	output.print(" | ");
 
-	stream.print(buttonL() ? 'L' : fillCharacter);
-	stream.print(buttonR() ? 'R' : fillCharacter);
+	output.print(buttonL() ? 'L' : fillCharacter);
+	output.print(buttonR() ? 'R' : fillCharacter);
 
-	stream.println();
+	output.println();
 }

--- a/src/controllers/SNESMiniController.h
+++ b/src/controllers/SNESMiniController.h
@@ -29,7 +29,7 @@ class SNESMiniController : public ClassicController {
 public:
 	SNESMiniController(NXC_I2C_TYPE& i2cBus = NXC_I2C_DEFAULT);
 	
-	void printDebug(Stream& stream=NXC_SERIAL_DEFAULT) const;
+	void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 };
 
 #endif

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -88,27 +88,27 @@ uint8_t ExtensionController::getControlData(uint8_t controlIndex) const {
 	return controlData[controlIndex];
 }
 
-void ExtensionController::printDebug(Stream& stream) const {
-	printDebugRaw(stream);
+void ExtensionController::printDebug(Print& output) const {
+	printDebugRaw(output);
 }
 
-void ExtensionController::printDebugID(Stream& stream) const {
+void ExtensionController::printDebugID(Print& output) const {
 	uint8_t idData[comms.IDSize];
 	boolean success = comms.requestIdentity(idData);
 
 	if (success) {
-		stream.print("ID: ");
-		NintendoExtensionCtrl::printRaw(idData, comms.IDSize, HEX, stream);
+		output.print("ID: ");
+		NintendoExtensionCtrl::printRaw(idData, comms.IDSize, HEX, output);
 	}
 	else {
-		stream.println("Bad ID Read");
+		output.println("Bad ID Read");
 	}
 }
 
-void ExtensionController::printDebugRaw(Stream& stream) const {
-	printDebugRaw(HEX, stream);
+void ExtensionController::printDebugRaw(Print& output) const {
+	printDebugRaw(HEX, output);
 }
 
-void ExtensionController::printDebugRaw(uint8_t baseFormat, Stream& stream) const {
-	NintendoExtensionCtrl::printRaw(controlData, ControlDataSize, baseFormat, stream);
+void ExtensionController::printDebugRaw(uint8_t baseFormat, Print& output) const {
+	NintendoExtensionCtrl::printRaw(controlData, ControlDataSize, baseFormat, output);
 }

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -46,10 +46,10 @@ public:
 
 	void setEnforceID(boolean enforce);
 
-	void printDebug(Stream& stream = NXC_SERIAL_DEFAULT) const;
-	void printDebugID(Stream& stream = NXC_SERIAL_DEFAULT) const;
-	void printDebugRaw(Stream& stream = NXC_SERIAL_DEFAULT) const;
-	void printDebugRaw(uint8_t baseFormat, Stream& stream = NXC_SERIAL_DEFAULT) const;
+	void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
+	void printDebugID(Print& output = NXC_SERIAL_DEFAULT) const;
+	void printDebugRaw(Print& output = NXC_SERIAL_DEFAULT) const;
+	void printDebugRaw(uint8_t baseFormat, Print& output = NXC_SERIAL_DEFAULT) const;
 
 	static const uint8_t ControlDataSize = 6;  // Enough for standard request size
 

--- a/src/internal/NXC_Utils.cpp
+++ b/src/internal/NXC_Utils.cpp
@@ -40,7 +40,7 @@ namespace NintendoExtensionCtrl {
 		return true;
 	}
 
-	void printRaw(const uint8_t * dataIn, uint8_t dataSize, uint8_t baseFormat, Stream& stream) {
+	void printRaw(const uint8_t * dataIn, uint8_t dataSize, uint8_t baseFormat, Print& output) {
 		char padChar = ' ';
 		if (baseFormat == BIN || baseFormat == HEX) {
 			padChar = '0';
@@ -58,7 +58,7 @@ namespace NintendoExtensionCtrl {
 			uint8_t dataOut = dataIn[i];
 
 			if (baseFormat == HEX) {
-				stream.print("0x");  // Hex prefix
+				output.print("0x");  // Hex prefix
 			}
 
 			// Calculate # of spaces that will be printed. Max - n = # to pad.
@@ -72,25 +72,25 @@ namespace NintendoExtensionCtrl {
 
 			// Print pad characters
 			for (int padOut = 0; padOut < (maxNPlaces - nPlaces); padOut++) {
-				stream.print(padChar);
+				output.print(padChar);
 			}
 
-			stream.print(dataOut, baseFormat);
+			output.print(dataOut, baseFormat);
 
 			if (i != dataSize - 1) {  // Print separators
-				stream.print(" | ");
+				output.print(" | ");
 			}
 		}
-		stream.println();
+		output.println();
 	}
 
-	void printRaw(uint8_t dataIn, uint8_t baseFormat, Stream& stream) {
-		printRaw(&dataIn, 1, baseFormat, stream);
+	void printRaw(uint8_t dataIn, uint8_t baseFormat, Print& output) {
+		printRaw(&dataIn, 1, baseFormat, output);
 	}
 
-	void printRepeat(char c, uint8_t nPrint, Stream& stream) {
+	void printRepeat(char c, uint8_t nPrint, Print& output) {
 		for (int i = 0; i < nPrint; i++) {
-			stream.print(c);
+			output.print(c);
 		}
 	}
 

--- a/src/internal/NXC_Utils.h
+++ b/src/internal/NXC_Utils.h
@@ -29,9 +29,9 @@ namespace NintendoExtensionCtrl {
 
 	// Utility
 	boolean verifyData(const uint8_t * dataIn, uint8_t dataSize);
-	void printRaw(const uint8_t * dataIn, uint8_t dataSize, uint8_t baseFormat = HEX, Stream& stream = NXC_SERIAL_DEFAULT);
-	void printRaw(uint8_t dataIn, uint8_t baseFormat = HEX, Stream& stream = NXC_SERIAL_DEFAULT);
-	void printRepeat(char c, uint8_t nPrint, Stream& stream = NXC_SERIAL_DEFAULT);
+	void printRaw(const uint8_t * dataIn, uint8_t dataSize, uint8_t baseFormat = HEX, Print& output = NXC_SERIAL_DEFAULT);
+	void printRaw(uint8_t dataIn, uint8_t baseFormat = HEX, Print& output = NXC_SERIAL_DEFAULT);
+	void printRepeat(char c, uint8_t nPrint, Print& output = NXC_SERIAL_DEFAULT);
 
 	class RolloverChange {
 	public:


### PR DESCRIPTION
For Arduino, Stream inherits from Print. The *print* class is what I actually want to be printing to with these debug functions, and since Serial is part of Print this works out. Plus it means that any community libraries (devices etc.) that use the Print class can be printed-to using the library's debug functions.