### PR TITLE
Constexpr Definitions for Declarations (Teensy compilation)

### DIFF
--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -24,6 +24,34 @@
 
 namespace NintendoExtensionCtrl {
 
+constexpr ControlDataMap::ByteMap ClassicController_Data::Maps::LeftJoyX;
+constexpr ControlDataMap::ByteMap ClassicController_Data::Maps::LeftJoyY;
+
+constexpr ControlDataMap::ByteMap ClassicController_Data::Maps::RightJoyX[3];
+constexpr ControlDataMap::ByteMap ClassicController_Data::Maps::RightJoyY;
+
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::DpadUp;
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::DpadDown;
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::DpadLeft;
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::DpadRight;
+
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::ButtonA;
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::ButtonB;
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::ButtonX;
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::ButtonY;
+
+constexpr ControlDataMap::ByteMap ClassicController_Data::Maps::TriggerL[2];
+constexpr ControlDataMap::ByteMap ClassicController_Data::Maps::TriggerR;
+
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::ButtonL;
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::ButtonR;
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::ButtonZL;
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::ButtonZR;
+
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::ButtonPlus;
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::ButtonMinus;
+constexpr ControlDataMap::BitMap  ClassicController_Data::Maps::ButtonHome;
+
 uint8_t ClassicController_Data::leftJoyX() const {
 	return getControlData(Maps::LeftJoyX);
 }

--- a/src/controllers/DJTurntable.cpp
+++ b/src/controllers/DJTurntable.cpp
@@ -24,6 +24,29 @@
 
 namespace NintendoExtensionCtrl {
 
+constexpr ControlDataMap::ByteMap DJTurntableController_Data::Maps::JoyX;
+constexpr ControlDataMap::ByteMap DJTurntableController_Data::Maps::JoyY;
+
+constexpr ControlDataMap::BitMap  DJTurntableController_Data::Maps::ButtonPlus;
+constexpr ControlDataMap::BitMap  DJTurntableController_Data::Maps::ButtonMinus;
+
+constexpr ControlDataMap::ByteMap DJTurntableController_Data::Maps::Left_Turntable;
+constexpr ControlDataMap::ByteMap DJTurntableController_Data::Maps::Left_TurntableSign;
+constexpr ControlDataMap::BitMap  DJTurntableController_Data::Maps::Left_ButtonGreen;
+constexpr ControlDataMap::BitMap  DJTurntableController_Data::Maps::Left_ButtonRed;
+constexpr ControlDataMap::BitMap  DJTurntableController_Data::Maps::Left_ButtonBlue;
+
+constexpr ControlDataMap::ByteMap DJTurntableController_Data::Maps::Right_Turntable[3];
+constexpr ControlDataMap::ByteMap DJTurntableController_Data::Maps::Right_TurntableSign;
+constexpr ControlDataMap::BitMap  DJTurntableController_Data::Maps::Right_ButtonGreen;
+constexpr ControlDataMap::BitMap  DJTurntableController_Data::Maps::Right_ButtonRed;
+constexpr ControlDataMap::BitMap  DJTurntableController_Data::Maps::Right_ButtonBlue;
+
+constexpr ControlDataMap::ByteMap DJTurntableController_Data::Maps::EffectDial[2];
+constexpr ControlDataMap::ByteMap DJTurntableController_Data::Maps::CrossfadeSlider;
+
+constexpr ControlDataMap::BitMap  DJTurntableController_Data::Maps::ButtonEuphoria;
+
 // Combined Turntable
 int8_t DJTurntableController_Data::turntable() const {
 	return left.turntable() + right.turntable();

--- a/src/controllers/DrumController.cpp
+++ b/src/controllers/DrumController.cpp
@@ -24,6 +24,25 @@
 
 namespace NintendoExtensionCtrl {
 
+constexpr ControlDataMap::ByteMap DrumController_Data::Maps::JoyX;
+constexpr ControlDataMap::ByteMap DrumController_Data::Maps::JoyY;
+
+constexpr ControlDataMap::BitMap  DrumController_Data::Maps::ButtonPlus;
+constexpr ControlDataMap::BitMap  DrumController_Data::Maps::ButtonMinus;
+
+constexpr ControlDataMap::BitMap  DrumController_Data::Maps::DrumRed;
+constexpr ControlDataMap::BitMap  DrumController_Data::Maps::DrumBlue;
+constexpr ControlDataMap::BitMap  DrumController_Data::Maps::DrumGreen;
+
+constexpr ControlDataMap::BitMap  DrumController_Data::Maps::CymbalYellow;
+constexpr ControlDataMap::BitMap  DrumController_Data::Maps::CymbalOrange;
+
+constexpr ControlDataMap::BitMap  DrumController_Data::Maps::Pedal;
+
+constexpr ControlDataMap::ByteMap DrumController_Data::Maps::Velocity;
+constexpr ControlDataMap::ByteMap DrumController_Data::Maps::VelocityID;
+constexpr ControlDataMap::BitMap  DrumController_Data::Maps::VelocityAvailable;
+
 uint8_t DrumController_Data::joyX() const {
 	return getControlData(Maps::JoyX);
 }

--- a/src/controllers/GuitarController.cpp
+++ b/src/controllers/GuitarController.cpp
@@ -24,6 +24,24 @@
 
 namespace NintendoExtensionCtrl {
 
+constexpr ControlDataMap::ByteMap GuitarController_Data::Maps::JoyX;
+constexpr ControlDataMap::ByteMap GuitarController_Data::Maps::JoyY;
+
+constexpr ControlDataMap::BitMap  GuitarController_Data::Maps::ButtonPlus;
+constexpr ControlDataMap::BitMap  GuitarController_Data::Maps::ButtonMinus;
+
+constexpr ControlDataMap::BitMap  GuitarController_Data::Maps::StrumUp;
+constexpr ControlDataMap::BitMap  GuitarController_Data::Maps::StrumDown;
+
+constexpr ControlDataMap::BitMap  GuitarController_Data::Maps::FretGreen;
+constexpr ControlDataMap::BitMap  GuitarController_Data::Maps::FretRed;
+constexpr ControlDataMap::BitMap  GuitarController_Data::Maps::FretYellow;
+constexpr ControlDataMap::BitMap  GuitarController_Data::Maps::FretBlue;
+constexpr ControlDataMap::BitMap  GuitarController_Data::Maps::FretOrange;
+
+constexpr ControlDataMap::ByteMap GuitarController_Data::Maps::Whammy;
+constexpr ControlDataMap::ByteMap GuitarController_Data::Maps::Touchbar;
+
 uint8_t GuitarController_Data::joyX() const {
 	return getControlData(Maps::JoyX);
 }

--- a/src/controllers/Nunchuk.cpp
+++ b/src/controllers/Nunchuk.cpp
@@ -24,6 +24,21 @@
 
 namespace NintendoExtensionCtrl {
 
+constexpr ControlDataMap::CtrlIndex Nunchuk_Data::Maps::JoyX;
+constexpr ControlDataMap::CtrlIndex Nunchuk_Data::Maps::JoyY;
+
+constexpr ControlDataMap::CtrlIndex Nunchuk_Data::Maps::AccelX_MSB;
+constexpr ControlDataMap::ByteMap   Nunchuk_Data::Maps::AccelX_LSB;
+
+constexpr ControlDataMap::CtrlIndex Nunchuk_Data::Maps::AccelY_MSB;
+constexpr ControlDataMap::ByteMap   Nunchuk_Data::Maps::AccelY_LSB;
+
+constexpr ControlDataMap::CtrlIndex Nunchuk_Data::Maps::AccelZ_MSB;
+constexpr ControlDataMap::ByteMap   Nunchuk_Data::Maps::AccelZ_LSB;
+
+constexpr ControlDataMap::BitMap    Nunchuk_Data::Maps::ButtonC;
+constexpr ControlDataMap::BitMap    Nunchuk_Data::Maps::ButtonZ;
+
 uint8_t Nunchuk_Data::joyX() const {
 	return getControlData(Maps::JoyX);
 }

--- a/src/controllers/Nunchuk.h
+++ b/src/controllers/Nunchuk.h
@@ -41,8 +41,8 @@ namespace NintendoExtensionCtrl {
 			constexpr static CtrlIndex AccelZ_MSB = 4;
 			constexpr static ByteMap   AccelZ_LSB = ByteMap(5, 2, 6, 6);
 
-			constexpr static BitMap  ButtonC = { 5, 1 };
-			constexpr static BitMap  ButtonZ = { 5, 0 };
+			constexpr static BitMap    ButtonC = { 5, 1 };
+			constexpr static BitMap    ButtonZ = { 5, 0 };
 		};
 
 		using ControlDataMap::ControlDataMap;


### PR DESCRIPTION
With the latest version ([0.5.3](https://github.com/dmadison/NintendoExtensionCtrl/releases/tag/v0.5.3)), all examples compile fine for me for the Arduino Uno but have issues for the Teensy boards*, throwing 'undefined reference' errors to mapping data. E.g. when compiling the `ClassicController_DebugPrint` example for the Teensy LC:

```
ClassicController.cpp.o*: In function NintendoExtensionCtrl::ClassicController_Data::leftJoyX() const
ClassicController.cpp:29: undefined reference to NintendoExtensionCtrl  ClassicController_Data  Maps  LeftJoyX
 
ClassicController.cpp.o*: In function NintendoExtensionCtrl::ClassicController_Data::leftJoyY() const
ClassicController.cpp:33: undefined reference to NintendoExtensionCtrl  ClassicController_Data  Maps  LeftJoyY
 
ClassicController.cpp.o*: In function NintendoExtensionCtrl::ClassicController_Data::rightJoyX() const
ClassicController.cpp:37: undefined reference to NintendoExtensionCtrl  ClassicController_Data  Maps  RightJoyX
ClassicController.cpp:37: undefined reference to NintendoExtensionCtrl  ClassicController_Data  Maps  RightJoyX
 
ClassicController.cpp.o*: In function NintendoExtensionCtrl::ClassicController_Data::rightJoyY() const
ClassicController.cpp:41: undefined reference to NintendoExtensionCtrl  ClassicController_Data  Maps  RightJoyY
 
ClassicController.cpp.o*: In function NintendoExtensionCtrl::ClassicController_Data::dpadUp() const
ClassicController.cpp:45: undefined reference to NintendoExtensionCtrl  ClassicController_Data  Maps  DpadUp
 
ClassicController.cpp.o*: In function NintendoExtensionCtrl::ClassicController_Data::dpadDown() const
ClassicController.cpp:49: undefined reference to NintendoExtensionCtrl  ClassicController_Data  Maps  DpadDown

...

Error linking for board Teensy LC
``` 

A few examples fail similarly for the Teensy 3.6, although with fewer complaints - almost solely about the array maps.

A little research says this has to do with the One Definition Rule (ODR). Even though a fully defined declaration should be a definition, there are a few exceptions, and apparently defining a constexpr static member of a class is one of those exceptions. If the data member is used inline it compiles fine, but if the data member is passed by reference the compiler throws a fit because no space has been allocated, and therefore there is no memory address to pass. Providing an explicit definition within a source file fixes the issue.

I was vaguely aware of this exception when I was initially writing the code, but it seemed every time I asked the compiler to pass by reference it would allocate memory for the mapping variables and not consider them constants**. When I got everything working on the Uno with just the definitions in a constexpr class, I assumed it was good and went on my way. Serves me right for not testing thoroughly. 

I'm not entirely sure *why* there wasn't a problem with the Arduino boards; it must be something different in the build process. Nevertheless, this PR should fix the issues on the other boards. For what it's worth, providing definitions does not increase the compilation size on the Uno, meaning the `Map` class is still being resolved as constant expression.

###### * Tested compiling all examples with a Serial interface for the Teensy 3.6 and Teensy LC, using Teensy 1.42 and Arduino 1.8.5.

###### ** This still happens if I try to pass a mapping value by reference through nested functions. See the comment in [the mapped array 'get' function](src/internal/NXC_DataMaps.h#L70). The code compiles, but allocates extra memory for the mapping values.

---

For whatever reason, I didn't test all of the examples with the Teensy boards after I made the constant expression changes. The only example I did test was the Nunchuk, which *worked* for some reason - presumably because it neither uses map arrays or a Classic Controller mapping. Maybe it's time to look into continuous integration...
