### PR TITLE
Anonymous I2C Functionality

### DIFF
--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -22,6 +22,8 @@
 
 #include "ExtensionController.h"
 
+using namespace NintendoExtensionCtrl;
+
 ExtensionController::ExtensionController(NXC_I2C_TYPE& i2cBus) : i2c(i2cBus) {}
 
 ExtensionController::ExtensionController(NXC_I2C_TYPE& i2cBus, ExtensionType conID)
@@ -32,7 +34,7 @@ void ExtensionController::begin() {
 }
 
 boolean ExtensionController::connect() {
-	if (NintendoExtensionCtrl::initialize(i2c)) {
+	if (initialize(i2c)) {
 		identifyController();
 		if (controllerIDMatches()) {
 			return update();  // Seed with initial values
@@ -77,8 +79,8 @@ ExtensionType ExtensionController::getConnectedID() const {
 }
 
 boolean ExtensionController::update() {
-	if (controllerIDMatches() && NintendoExtensionCtrl::requestControlData(i2c, ControlDataSize, controlData)) {
-		return NintendoExtensionCtrl::verifyData(controlData, ControlDataSize);
+	if (controllerIDMatches() && requestControlData(i2c, ControlDataSize, controlData)) {
+		return verifyData(controlData, ControlDataSize);
 	}
 	
 	return false;  // Something went wrong :(
@@ -93,12 +95,12 @@ void ExtensionController::printDebug(Print& output) const {
 }
 
 void ExtensionController::printDebugID(Print& output) const {
-	uint8_t idData[NintendoExtensionCtrl::ID_Size];
-	boolean success = NintendoExtensionCtrl::requestIdentity(i2c, idData);
+	uint8_t idData[ID_Size];
+	boolean success = requestIdentity(i2c, idData);
 
 	if (success) {
 		output.print("ID: ");
-		NintendoExtensionCtrl::printRaw(idData, NintendoExtensionCtrl::ID_Size, HEX, output);
+		printRaw(idData, NintendoExtensionCtrl::ID_Size, HEX, output);
 	}
 	else {
 		output.println("Bad ID Read");
@@ -110,5 +112,5 @@ void ExtensionController::printDebugRaw(Print& output) const {
 }
 
 void ExtensionController::printDebugRaw(uint8_t baseFormat, Print& output) const {
-	NintendoExtensionCtrl::printRaw(controlData, ControlDataSize, baseFormat, output);
+	printRaw(controlData, ControlDataSize, baseFormat, output);
 }

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -52,6 +52,7 @@ public:
 	void printDebugRaw(uint8_t baseFormat, Print& output = NXC_SERIAL_DEFAULT) const;
 
 	static const uint8_t ControlDataSize = 6;  // Enough for standard request size
+	NXC_I2C_TYPE & i2c;  // Reference for the I2C (Wire) class
 
 protected:
 	ExtensionController(NXC_I2C_TYPE& i2cBus, ExtensionType conID);
@@ -62,8 +63,6 @@ private:
 	const ExtensionType ID_Limit = ExtensionType::AnyController;
 	ExtensionType connectedID = ExtensionType::NoController;
 	uint8_t controlData[ControlDataSize];
-
-	NintendoExtensionCtrl::ExtensionComms comms;
 };
 
 #include "NXC_DataMaps.h"

--- a/src/internal/NXC_Comms.h
+++ b/src/internal/NXC_Comms.h
@@ -87,6 +87,10 @@ namespace NintendoExtensionCtrl {
 		return true;
 	}
 
+	inline boolean requestData(NXC_I2C_TYPE &i2c, uint8_t ptr, size_t size, uint8_t * data) {
+		return i2c_readDataArray(i2c, I2C_Addr, ptr, size, data);
+	}
+
 	inline boolean requestControlData(NXC_I2C_TYPE &i2c, size_t size, uint8_t * controlData) {
 		return i2c_readDataArray(i2c, I2C_Addr, 0x00, size, controlData);
 	}


### PR DESCRIPTION
There was no compelling reason to keep these functions as part of classes with static constants as opposed to anonymous namespace functions with namespace-scope constants. Moving them out of the class structure also allows keeping an I2C object as a public reference in the `ExtensionController` class, allowing the user to manipulate the bus directly without having to keep track of it somewhere else (e.g. in changing the bus speed)

The only downside is that the program needs to pass a reference to the I2C object for each call, but I think that's worth the tradeoff.