### PR TITLE
Variable Request Size

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Plug in your controller, upload the example to your board, and have fun!
 * NES Mini Controller
 * SNES Mini Controller
 
-Currently the library supports any extension controller using unencrypted communication and data reporting mode [0x37 (6 byte request)](http://wiibrew.org/wiki/Wiimote#0x37:_Core_Buttons_and_Accelerometer_with_10_IR_bytes_and_6_Extension_Bytes). If you'd like to add support for another controller, I've written [a short guide](extras/AddingControllers.md) that should be helpful. 
+Currently the library supports any extension controller using unencrypted communication. If you'd like to add support for another controller, I've written [a short guide](extras/AddingControllers.md) that should be helpful. 
 
 ## License
 This library is licensed under the terms of the [GNU Lesser General Public License (LGPL)](https://www.gnu.org/licenses/lgpl.html), either version 3 of the License, or (at your option) any later version.

--- a/examples/Any/IdentifyController/IdentifyController.ino
+++ b/examples/Any/IdentifyController/IdentifyController.ino
@@ -57,6 +57,7 @@ void setup() {
 		case(ExtensionType::DJTurntableController):
 			Serial.println("DJ turntable connected!");
 			break;
+		default: break;
 	}
 	controller.printDebugID();
 }

--- a/examples/Any/IdentifyController/IdentifyController.ino
+++ b/examples/Any/IdentifyController/IdentifyController.ino
@@ -40,13 +40,13 @@ void setup() {
 			Serial.println("No controller detected");
 			break;
 		case(ExtensionType::UnknownController):
-			Serial.println("Unknown controller detected");
+			Serial.println("Unknown controller connected");
 			break;
 		case(ExtensionType::Nunchuk):
-			Serial.println("Nunchuk detected!");
+			Serial.println("Nunchuk connected!");
 			break;
 		case(ExtensionType::ClassicController):
-			Serial.println("Classic Controller detected!");
+			Serial.println("Classic Controller connected!");
 			break;
 		case(ExtensionType::GuitarController):
 			Serial.println("Guitar controller connected!");

--- a/examples/Any/IdentifyController/IdentifyController.ino
+++ b/examples/Any/IdentifyController/IdentifyController.ino
@@ -33,7 +33,7 @@ void setup() {
 	controller.begin();
 	controller.connect();
 
-	ExtensionType conType = controller.getConnectedID();
+	ExtensionType conType = controller.getControllerType();
 
 	switch (conType) {
 		case(ExtensionType::NoController):

--- a/examples/Any/MultipleTypes/MultipleTypes.ino
+++ b/examples/Any/MultipleTypes/MultipleTypes.ino
@@ -45,7 +45,7 @@ void loop() {
 	boolean success = controller.update();  // Get new data from the controller
 
 	if (success == true) {  // We've got data!
-		ExtensionType conType = controller.getConnectedID();
+		ExtensionType conType = controller.getControllerType();
 
 		switch (conType) {
 			case(ExtensionType::Nunchuk):

--- a/extras/AddingControllers.md
+++ b/extras/AddingControllers.md
@@ -18,7 +18,7 @@ namespace NintendoExtensionCtrl {
 ```
 
 ## Step #2: Building Your Data Maps
-The next step is to add the data maps for your controller. These define where the data for each control input lies within in the data array. Currently (v0.5.2), all controllers use the Wiimote 0x37 data reporting mode, returning 6 bytes of control data starting at offset 0x00. If your controller requires sending more than 6 bytes of data to function, you'll need to modify the `ExtensionController` class to increase the size of the control data array.
+The next step is to add the data maps for your controller. These define where the data for each control input lies within in the data array. Currently (v0.6.0), all controllers use the Wiimote 0x37 data reporting mode by default, returning 6 bytes of control data starting at offset 0x00. If your controller requires more than 6 bytes of data to function, you will have to call `setRequestSize`on the `ExtensionController` object with the number of bytes to request.
 
 Each map represents the size and position for all of the data of a control surface (button, joystick, etc.). The library has three data types for this, each with a different purpose:
 

--- a/extras/AddingControllers.md
+++ b/extras/AddingControllers.md
@@ -147,6 +147,12 @@ Now that your controller definition is nearly done, it's time to add its identit
 
 Open up the [`NXC_Identity.h`](../src/internal/NXC_Identity.h) file and add your controller name to the `ExtensionType` enumeration. Then, modify the `identifyController` function so that it will return your controller's ID if the identity bytes match. You can run the [`IdentifyController`](../examples/Any/IdentifyController/IdentifyController.ino) example to fetch the string of ID bytes.
 
+Once that's done, head back to your controller's header file and add a public `id` variable to store the controller's identity. This will limit connections to this specific type and report problems if the type doesn't match.
+
+```
+static const ExtensionType id = ExtensionType::ClassicController;
+```
+
 You will also need to edit the switch statement in the `IdentifyControllers` example to add your controller to the 'switch' statement.
 
 ## Step #6: Create the Combined Class
@@ -154,8 +160,7 @@ The last step to get your controller working is to create a combined class that 
 
 ```C++
 typedef NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::YourController_Data, ExtensionType::YourController>
-	YourController;
+	<NintendoExtensionCtrl::YourController_Data> YourController;
 ```
 
 Be sure to place this *outside* of the namespace, in the header file. See other controller definitions for reference.

--- a/keywords.txt
+++ b/keywords.txt
@@ -44,7 +44,6 @@ connect	KEYWORD2
 reconnect	KEYWORD2
 
 update	KEYWORD2
-identifyController	KEYWORD2
 
 reset	KEYWORD2
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -51,6 +51,8 @@ reset	KEYWORD2
 getConnectedID	KEYWORD2
 getControlData	KEYWORD2
 
+setRequestSize	KEYWORD2
+
 printDebug	KEYWORD2
 printDebugID	KEYWORD2
 printDebugRaw	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -48,7 +48,7 @@ identifyController	KEYWORD2
 
 reset	KEYWORD2
 
-getConnectedID	KEYWORD2
+getControllerType	KEYWORD2
 getControlData	KEYWORD2
 
 setRequestSize	KEYWORD2

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -59,6 +59,7 @@ namespace NintendoExtensionCtrl {
 		};
 
 		using ControlDataMap::ControlDataMap;
+		static const ExtensionType id = ExtensionType::ClassicController;
 
 		uint8_t leftJoyX() const;  // 6 bits, 0-63
 		uint8_t leftJoyY() const;
@@ -98,7 +99,6 @@ namespace NintendoExtensionCtrl {
 }
 
 typedef NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::ClassicController_Data, ExtensionType::ClassicController>
-	ClassicController;
+	<NintendoExtensionCtrl::ClassicController_Data>	ClassicController;
 
 #endif

--- a/src/controllers/DJTurntable.h
+++ b/src/controllers/DJTurntable.h
@@ -56,6 +56,7 @@ namespace NintendoExtensionCtrl {
 		};
 
 		DJTurntableController_Data(ExtensionController & dataSource) : ControlDataMap(dataSource), left(*this), right(*this) {}
+		static const ExtensionType id = ExtensionType::DJTurntableController;
 
 		enum class TurntableConfig {
 			BaseOnly,
@@ -148,7 +149,6 @@ namespace NintendoExtensionCtrl {
 }
 
 typedef NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::DJTurntableController_Data, ExtensionType::DJTurntableController>
-	DJTurntableController;
+	<NintendoExtensionCtrl::DJTurntableController_Data> DJTurntableController;
 
 #endif

--- a/src/controllers/DrumController.h
+++ b/src/controllers/DrumController.h
@@ -52,6 +52,7 @@ namespace NintendoExtensionCtrl {
 		};
 
 		using ControlDataMap::ControlDataMap;
+		static const ExtensionType id = ExtensionType::DrumController;
 
 		enum VelocityID : uint8_t {
 			None = 0x1F,
@@ -92,13 +93,13 @@ namespace NintendoExtensionCtrl {
 		uint8_t velocityPedal() const;
 
 		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
+
 	private:
 		boolean validVelocityID(uint8_t idIn) const;
 	};
 }
 
 typedef NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::DrumController_Data, ExtensionType::DrumController>
-	DrumController;
+	<NintendoExtensionCtrl::DrumController_Data> DrumController;
 
 #endif

--- a/src/controllers/GuitarController.h
+++ b/src/controllers/GuitarController.h
@@ -51,6 +51,7 @@ namespace NintendoExtensionCtrl {
 		};
 
 		using ControlDataMap::ControlDataMap;
+		static const ExtensionType id = ExtensionType::GuitarController;
 
 		uint8_t joyX() const;  // 6 bits, 0-63
 		uint8_t joyY() const;
@@ -87,7 +88,6 @@ namespace NintendoExtensionCtrl {
 }
 
 typedef NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::GuitarController_Data, ExtensionType::GuitarController>
-	GuitarController;
+	<NintendoExtensionCtrl::GuitarController_Data> GuitarController;
 
 #endif

--- a/src/controllers/Nunchuk.h
+++ b/src/controllers/Nunchuk.h
@@ -46,6 +46,7 @@ namespace NintendoExtensionCtrl {
 		};
 
 		using ControlDataMap::ControlDataMap;
+		static const ExtensionType id = ExtensionType::Nunchuk;
 
 		uint8_t joyX() const;  // 8 bits, 0-255
 		uint8_t joyY() const;
@@ -65,7 +66,6 @@ namespace NintendoExtensionCtrl {
 }
 
 typedef NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::Nunchuk_Data, ExtensionType::Nunchuk>
-	Nunchuk;
+	<NintendoExtensionCtrl::Nunchuk_Data> Nunchuk;
 
 #endif

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -35,17 +35,17 @@ void ExtensionController::begin() {
 }
 
 boolean ExtensionController::connect() {
+	boolean success = false;
+
 	if (initialize(i2c)) {
 		identifyController();
-		if (controllerIDMatches()) {
-			return update();  // Seed with initial values
-		}
+		success = update();  // Seed with initial values
 	}
 	else {
 		connectedID = ExtensionType::NoController;  // Bad init, nothing connected
 	}
 
-	return false;
+	return success;
 }
 
 boolean ExtensionController::reconnect() {

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -58,9 +58,10 @@ ExtensionType ExtensionController::identifyController() {
 
 void ExtensionController::reset() {
 	connectedID = ExtensionType::NoController;
-	for (int i = 0; i < ControlDataSize; i++) {
+	for (size_t i = 0; i < MaxRequestSize; i++) {
 		controlData[i] = 0;
 	}
+	requestSize = MinRequestSize;
 }
 
 boolean ExtensionController::controllerIDMatches() const {
@@ -79,8 +80,8 @@ ExtensionType ExtensionController::getConnectedID() const {
 }
 
 boolean ExtensionController::update() {
-	if (controllerIDMatches() && requestControlData(i2c, ControlDataSize, controlData)) {
-		return verifyData(controlData, ControlDataSize);
+	if (controllerIDMatches() && requestControlData(i2c, requestSize, controlData)) {
+		return verifyData(controlData, requestSize);
 	}
 	
 	return false;  // Something went wrong :(
@@ -88,6 +89,12 @@ boolean ExtensionController::update() {
 
 uint8_t ExtensionController::getControlData(uint8_t controlIndex) const {
 	return controlData[controlIndex];
+}
+
+void ExtensionController::setRequestSize(size_t r) {
+	if (r >= MinRequestSize && r <= MaxRequestSize) {
+		requestSize = (uint8_t) r;
+	}
 }
 
 void ExtensionController::printDebug(Print& output) const {
@@ -112,5 +119,5 @@ void ExtensionController::printDebugRaw(Print& output) const {
 }
 
 void ExtensionController::printDebugRaw(uint8_t baseFormat, Print& output) const {
-	printRaw(controlData, ControlDataSize, baseFormat, output);
+	printRaw(controlData, requestSize, baseFormat, output);
 }

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -35,7 +35,7 @@ void ExtensionController::begin() {
 }
 
 boolean ExtensionController::connect() {
-	reset();  // Clear current data
+	disconnect();  // Clear current data
 	return reconnect();
 }
 
@@ -53,14 +53,18 @@ boolean ExtensionController::reconnect() {
 	return success;
 }
 
-void ExtensionController::identifyController() {
-	connectedID = NintendoExtensionCtrl::identifyController(i2c);  // Polls the controller for its identity
+void ExtensionController::disconnect() {
+	connectedID = ExtensionType::NoController;  // Nothing connected
+	memset(controlData, 0x00, MaxRequestSize);  // Clear control data
 }
 
 void ExtensionController::reset() {
-	connectedID = ExtensionType::NoController;  // Nothing connected
-	memset(controlData, 0x00, MaxRequestSize);  // No control data
+	disconnect();
 	requestSize = MinRequestSize;  // Request size back to minimum
+}
+
+void ExtensionController::identifyController() {
+	connectedID = NintendoExtensionCtrl::identifyController(i2c);  // Polls the controller for its identity
 }
 
 boolean ExtensionController::controllerIDMatches() const {

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -52,8 +52,8 @@ boolean ExtensionController::reconnect() {
 	return connect();
 }
 
-ExtensionType ExtensionController::identifyController() {
-	return connectedID = NintendoExtensionCtrl::identifyController(i2c);  // Polls the controller for its identity
+void ExtensionController::identifyController() {
+	connectedID = NintendoExtensionCtrl::identifyController(i2c);  // Polls the controller for its identity
 }
 
 void ExtensionController::reset() {

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -35,6 +35,11 @@ void ExtensionController::begin() {
 }
 
 boolean ExtensionController::connect() {
+	reset();  // Clear current data
+	return reconnect();
+}
+
+boolean ExtensionController::reconnect() {
 	boolean success = false;
 
 	if (initialize(i2c)) {
@@ -46,10 +51,6 @@ boolean ExtensionController::connect() {
 	}
 
 	return success;
-}
-
-boolean ExtensionController::reconnect() {
-	return connect();
 }
 
 void ExtensionController::identifyController() {

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -57,11 +57,9 @@ void ExtensionController::identifyController() {
 }
 
 void ExtensionController::reset() {
-	connectedID = ExtensionType::NoController;
-	for (size_t i = 0; i < MaxRequestSize; i++) {
-		controlData[i] = 0;
-	}
-	requestSize = MinRequestSize;
+	connectedID = ExtensionType::NoController;  // Nothing connected
+	memset(controlData, 0x00, MaxRequestSize);  // No control data
+	requestSize = MinRequestSize;  // Request size back to minimum
 }
 
 boolean ExtensionController::controllerIDMatches() const {

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -49,7 +49,6 @@ boolean ExtensionController::connect() {
 }
 
 boolean ExtensionController::reconnect() {
-	reset();
 	return connect();
 }
 

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -24,7 +24,8 @@
 
 using namespace NintendoExtensionCtrl;
 
-ExtensionController::ExtensionController(NXC_I2C_TYPE& i2cBus) : i2c(i2cBus) {}
+ExtensionController::ExtensionController(NXC_I2C_TYPE& i2cBus) 
+	: ExtensionController(i2cBus, ExtensionType::AnyController) {}
 
 ExtensionController::ExtensionController(NXC_I2C_TYPE& i2cBus, ExtensionType conID)
 	: i2c(i2cBus), ID_Limit(conID) {}

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -75,7 +75,7 @@ boolean ExtensionController::controllerIDMatches() const {
 	return false;  // Enforced types or no controller connected
 }
 
-ExtensionType ExtensionController::getConnectedID() const {
+ExtensionType ExtensionController::getControllerType() const {
 	return connectedID;
 }
 

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -41,7 +41,7 @@ public:
 
 	void reset();
 
-	ExtensionType getConnectedID() const;
+	ExtensionType getControllerType() const;
 	uint8_t getControlData(uint8_t controlIndex) const;
 
 	void setRequestSize(size_t size);

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -43,7 +43,7 @@ public:
 	ExtensionType getControllerType() const;
 	uint8_t getControlData(uint8_t controlIndex) const;
 
-	void setRequestSize(size_t size);
+	void setRequestSize(size_t size = MinRequestSize);
 
 	void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 	void printDebugID(Print& output = NXC_SERIAL_DEFAULT) const;

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -50,9 +50,8 @@ public:
 	void printDebugRaw(Print& output = NXC_SERIAL_DEFAULT) const;
 	void printDebugRaw(uint8_t baseFormat, Print& output = NXC_SERIAL_DEFAULT) const;
 
-	static const uint8_t MinRequestSize = 6;  // Shortest reporting mode (0x37)
-	static const uint8_t MaxRequestSize = 8;  // Longest required reporting mode (0x32)
-	                                          //  for current controllers (NES Mini knockoff)
+	static const uint8_t MinRequestSize = 6;   // Smallest reporting mode (0x37)
+	static const uint8_t MaxRequestSize = 21;  // Largest reporting mode (0x3d)
 
 	NXC_I2C_TYPE & i2c;  // Reference for the I2C (Wire) class
 

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -59,6 +59,7 @@ protected:
 	ExtensionController(NXC_I2C_TYPE& i2cBus, ExtensionType conID);
 
 private:
+	void disconnect();
 	void identifyController();
 	boolean controllerIDMatches() const;
 

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -44,8 +44,6 @@ public:
 	ExtensionType getConnectedID() const;
 	uint8_t getControlData(uint8_t controlIndex) const;
 
-	void setEnforceID(boolean enforce);
-
 	void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 	void printDebugID(Print& output = NXC_SERIAL_DEFAULT) const;
 	void printDebugRaw(Print& output = NXC_SERIAL_DEFAULT) const;

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -44,12 +44,17 @@ public:
 	ExtensionType getConnectedID() const;
 	uint8_t getControlData(uint8_t controlIndex) const;
 
+	void setRequestSize(size_t size);
+
 	void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 	void printDebugID(Print& output = NXC_SERIAL_DEFAULT) const;
 	void printDebugRaw(Print& output = NXC_SERIAL_DEFAULT) const;
 	void printDebugRaw(uint8_t baseFormat, Print& output = NXC_SERIAL_DEFAULT) const;
 
-	static const uint8_t ControlDataSize = 6;  // Enough for standard request size
+	static const uint8_t MinRequestSize = 6;  // Shortest reporting mode (0x37)
+	static const uint8_t MaxRequestSize = 8;  // Longest required reporting mode (0x32)
+	                                          //  for current controllers (NES Mini knockoff)
+
 	NXC_I2C_TYPE & i2c;  // Reference for the I2C (Wire) class
 
 protected:
@@ -60,7 +65,9 @@ private:
 
 	const ExtensionType ID_Limit = ExtensionType::AnyController;
 	ExtensionType connectedID = ExtensionType::NoController;
-	uint8_t controlData[ControlDataSize];
+
+	uint8_t requestSize = MinRequestSize;
+	uint8_t controlData[MaxRequestSize];
 };
 
 #include "NXC_DataMaps.h"

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -37,7 +37,6 @@ public:
 	boolean reconnect();
 
 	boolean update();
-	ExtensionType identifyController();
 
 	void reset();
 
@@ -61,6 +60,7 @@ protected:
 	ExtensionController(NXC_I2C_TYPE& i2cBus, ExtensionType conID);
 
 private:
+	void identifyController();
 	boolean controllerIDMatches() const;
 
 	const ExtensionType ID_Limit = ExtensionType::AnyController;

--- a/src/internal/NXC_DataMaps.h
+++ b/src/internal/NXC_DataMaps.h
@@ -87,11 +87,11 @@ namespace NintendoExtensionCtrl {
 		const ExtensionController & ControlData;
 	};
 
-	template <class ControllerMap, ExtensionType controllerID>
+	template <class ControllerMap>
 	class BuildControllerClass : public ExtensionController, public ControllerMap {
 	public:
 		BuildControllerClass(NXC_I2C_TYPE& i2cBus = NXC_I2C_DEFAULT) :
-			ExtensionController(i2cBus, controllerID),
+			ExtensionController(i2cBus, ControllerMap::id),
 			ControllerMap(*(static_cast<ExtensionController*>(this))) {}
 
 		using ControllerMap::printDebug;  // Use the controller-specific print


### PR DESCRIPTION
This pr changes the control data request size to be configurable by the user. It also increases the max possible control data request size from 6 (minimum, reporting mode 0x37) to 21 (maximum, reporting mode 0x3d). See the Wiimote [data reporting](http://wiibrew.org/wiki/Wiimote#Data_Reporting) section on WiiBrew for more information.

This change future-proofs the library and makes it possible to request the max possible number of bytes from any given extension controller. It also enables user-created support for 3rd party NES controllers (#33). This is at a cost of a memory increase of 15 bytes. I think that's a worthwhile tradeoff.

Misc changes:
* Removes `setEnforceID` declaration. Should've been done when user-set enforceID was removed in 2651e71.
* `getConnectedID` has been refactored as `getControllerType`, which is clearer and more to the point.
* Removed user-facing `identifyController` function. Controller identification should follow the `connect` / `getControllerType` idiom.
* Fixed `IdentifyController` example - warning and language consistency.
* Extension controller data is now reset on connection rather than reconnection (logically). If the user is attempting to re-connect to a controller they wouldn't want their data erased now would they?
* Extension type (enum) is now saved within controller-specific data class. This strongly couples the data classes to their associated enumerations, rather than injecting them by hand in the `Build` template.