### PR TITLE
Fix getControlData() ambiguous function call

### DIFF
--- a/src/internal/NXC_DataMaps.h
+++ b/src/internal/NXC_DataMaps.h
@@ -95,6 +95,7 @@ namespace NintendoExtensionCtrl {
 			ExtensionController(i2cBus, ControllerMap::id),
 			ControllerMap(*(static_cast<ExtensionController*>(this))) {}
 
+		using ExtensionController::getControlData;  // Using the direct 'get' function
 		using ControllerMap::printDebug;  // Use the controller-specific print
 
 		typedef ControllerMap Data;  // Make controller data class easily accessible

--- a/src/internal/NXC_DataMaps.h
+++ b/src/internal/NXC_DataMaps.h
@@ -55,6 +55,7 @@ namespace NintendoExtensionCtrl {
 
 		ControlDataMap(ExtensionController & dataSource) : ControlData(dataSource) {}
 
+	protected:
 		uint8_t getControlData(uint8_t index) const {
 			return ControlData.getControlData(index);
 		}


### PR DESCRIPTION
When the `ExtensionController` and `ControlDataMap` classes are combined into the controller-specific classes for convenience, there are two `getControlData(uint8_t)` functions. The former pulls data from its member array, the latter calls the former function using a reference to the object. When the user calls `getControlData`, the compiler doesn't know which function to use and throws an error.

Commit 1 (3e63903) makes the various data transformation 'get' functions in ControlDataMap protected, as they don't need to be exposed to the user for the library to work as intended.
Commit 2 (e9bcc55) explicitly tells the compiler to use the `ExtensionController` version of the function when building the combined class.

I thought that I only needed commit 1 to fix this bug, but it turns out that because the class is using multiple inheritance the compiler notices the name clash before it resolves accessibility. So even though it can't access the function that's causing the ambiguous call, it still throws an error because it doesn't know which of the functions to *check* for accessibility. Or so I understand.

Evidently this has been broken for several months, but no one has tried to do any calculations with the raw data function and a combined class so I haven't noticed. It's not something that you typically *would* use with a combined class instance - that is, if the controller class is fully featured why would you need to access the raw data? It's just a remnant from inheriting the `ExtensionControler` class in full to keep the API noob-friendly.

Regardless, this should fix the problem in case someone wants to do it.