### PR TITLE
NES Mini Knockoff Support

### DIFF
--- a/examples/NES Mini/NES_DebugPrint/NES_DebugPrint.ino
+++ b/examples/NES Mini/NES_DebugPrint/NES_DebugPrint.ino
@@ -37,6 +37,10 @@ void setup() {
 		Serial.println("Classic Controller not detected!");
 		delay(1000);
 	}
+
+	if (nes.isKnockoff()) {  // Uh oh, looks like your controller isn't genuine?
+		nes.setRequestSize(8);  // Requires 8 or more bytes for knockoff controllers
+	}
 }
 
 void loop() {

--- a/examples/NES Mini/NES_Demo/NES_Demo.ino
+++ b/examples/NES Mini/NES_Demo/NES_Demo.ino
@@ -36,6 +36,10 @@ void setup() {
 		Serial.println("NES Classic Controller not detected!");
 		delay(1000);
 	}
+
+	if (nes.isKnockoff()) {  // Uh oh, looks like your controller isn't genuine?
+		nes.setRequestSize(8);  // Requires 8 or more bytes for knockoff controllers
+	}
 }
 
 void loop() {

--- a/keywords.txt
+++ b/keywords.txt
@@ -186,6 +186,7 @@ getNumTurntables	KEYWORD2
 
 ## NES Mini Controller
 # (Covered by the Classic Controller keywords)
+isKnockoff	KEYWORD2
 
 ## SNES Mini Controller
 # (Covered by the Classic Controller keywords)

--- a/src/controllers/NESMiniController.cpp
+++ b/src/controllers/NESMiniController.cpp
@@ -25,43 +25,35 @@
 namespace NintendoExtensionCtrl {
 
 boolean NESMiniController_Data::dpadUp() const {
-	if (isKnockoff()) { return getControlBit(Maps::Knockoff_DpadUp); }
-	return ClassicController_Data::dpadUp();
+	return knockoffButton<&ClassicController_Data::dpadUp>(Maps::Knockoff_DpadUp);
 }
 
 boolean NESMiniController_Data::dpadDown() const {
-	if (isKnockoff()) { return getControlBit(Maps::Knockoff_DpadDown); }
-	return ClassicController_Data::dpadDown();
+	return knockoffButton<&ClassicController_Data::dpadDown>(Maps::Knockoff_DpadDown);
 }
 
 boolean NESMiniController_Data::dpadLeft() const {
-	if (isKnockoff()) { return getControlBit(Maps::Knockoff_DpadLeft); }
-	return ClassicController_Data::dpadLeft();
+	return knockoffButton<&ClassicController_Data::dpadLeft>(Maps::Knockoff_DpadLeft);
 }
 
 boolean NESMiniController_Data::dpadRight() const {
-	if (isKnockoff()) { return getControlBit(Maps::Knockoff_DpadRight); }
-	return ClassicController_Data::dpadRight();
+	return knockoffButton<&ClassicController_Data::dpadRight>(Maps::Knockoff_DpadRight);
 }
 
 boolean NESMiniController_Data::buttonA() const {
-	if (isKnockoff()) { return getControlBit(Maps::Knockoff_ButtonA); }
-	return ClassicController_Data::buttonA();
+	return knockoffButton<&ClassicController_Data::buttonA>(Maps::Knockoff_ButtonA);
 }
 
 boolean NESMiniController_Data::buttonB() const {
-	if (isKnockoff()) { return getControlBit(Maps::Knockoff_ButtonB); }
-	return ClassicController_Data::buttonB();
+	return knockoffButton<&ClassicController_Data::buttonB>(Maps::Knockoff_ButtonB);
 }
 
 boolean NESMiniController_Data::buttonStart() const {
-	if (isKnockoff()) { return getControlBit(Maps::Knockoff_ButtonStart); }
-	return ClassicController_Data::buttonStart();
+	return knockoffButton<&ClassicController_Data::buttonStart>(Maps::Knockoff_ButtonStart);
 }
 
 boolean NESMiniController_Data::buttonSelect() const {
-	if (isKnockoff()) { return getControlBit(Maps::Knockoff_ButtonSelect); }
-	return ClassicController_Data::buttonSelect();
+	return knockoffButton<&ClassicController_Data::buttonSelect>(Maps::Knockoff_ButtonSelect);
 }
 
 void NESMiniController_Data::printDebug(Print& output) const {

--- a/src/controllers/NESMiniController.cpp
+++ b/src/controllers/NESMiniController.cpp
@@ -22,9 +22,49 @@
 
 #include "NESMiniController.h"
 
-NESMiniController::NESMiniController(NXC_I2C_TYPE& i2cBus) : ::ClassicController(i2cBus) {}
+namespace NintendoExtensionCtrl {
 
-void NESMiniController::printDebug(Print& output) const {
+boolean NESMiniController_Data::dpadUp() const {
+	if (isKnockoff()) { return getControlBit(Maps::Knockoff_DpadUp); }
+	return ClassicController_Data::dpadUp();
+}
+
+boolean NESMiniController_Data::dpadDown() const {
+	if (isKnockoff()) { return getControlBit(Maps::Knockoff_DpadDown); }
+	return ClassicController_Data::dpadDown();
+}
+
+boolean NESMiniController_Data::dpadLeft() const {
+	if (isKnockoff()) { return getControlBit(Maps::Knockoff_DpadLeft); }
+	return ClassicController_Data::dpadLeft();
+}
+
+boolean NESMiniController_Data::dpadRight() const {
+	if (isKnockoff()) { return getControlBit(Maps::Knockoff_DpadRight); }
+	return ClassicController_Data::dpadRight();
+}
+
+boolean NESMiniController_Data::buttonA() const {
+	if (isKnockoff()) { return getControlBit(Maps::Knockoff_ButtonA); }
+	return ClassicController_Data::buttonA();
+}
+
+boolean NESMiniController_Data::buttonB() const {
+	if (isKnockoff()) { return getControlBit(Maps::Knockoff_ButtonB); }
+	return ClassicController_Data::buttonB();
+}
+
+boolean NESMiniController_Data::buttonStart() const {
+	if (isKnockoff()) { return getControlBit(Maps::Knockoff_ButtonStart); }
+	return ClassicController_Data::buttonStart();
+}
+
+boolean NESMiniController_Data::buttonSelect() const {
+	if (isKnockoff()) { return getControlBit(Maps::Knockoff_ButtonSelect); }
+	return ClassicController_Data::buttonSelect();
+}
+
+void NESMiniController_Data::printDebug(Print& output) const {
 	const char fillCharacter = '_';
 	
 	output.print("NES ");
@@ -46,3 +86,32 @@ void NESMiniController::printDebug(Print& output) const {
 
 	output.println();
 }
+
+boolean NESMiniController_Data::isKnockoff() const {
+	// The NES knockoffs I've come across seem to display the same unchanging pattern
+	// for the first six control bytes:
+	//
+	//     0x81, 0x81, 0x81, 0x81, 0x00, 0x00
+	//
+	// This is mostly garbage data that doesn't line up with the Classic Controller
+	// at all. Using the library's debug output, here is what it translates to:
+	//
+	//    <^v> | -H+ | ABXY L : (1, 1) R : (21, 1) | LT : 4X RT : 1X Z : LR
+	//
+	// You'll notice a few things. ALL possible buttons are pressed. The left analog 
+	// stick is completely down and to the left, while the right analog stick is down
+	// and to the right. On the back, both trigger "fully depressed" buttons are
+	// down, and yet the analog trigger values are very low. In short, this is a
+	// difficult if not impossible state for a normal Classic Controller to be in.
+	// Because of that, we can reasonably assume that if the bytes match this then the
+	// connected controller is an NES Knockoff, and can be treated accordingly. 
+
+	return getControlData(0) == 0x81 &&  // RX 4:3, LX
+	       getControlData(1) == 0x81 &&  // RX 2:1, LY
+	       getControlData(2) == 0x81 &&  // RX 0, LT 4:3, RY
+	       getControlData(3) == 0x81 &&  // LT 2:0, RT
+	       getControlData(4) == 0x00 &&  // Button packet 1 (all pressed)
+	       getControlData(5) == 0x00;    // Button packet 2 (all pressed)
+}
+
+}  // End "NintendoExtensionCtrl" namespace

--- a/src/controllers/NESMiniController.h
+++ b/src/controllers/NESMiniController.h
@@ -40,7 +40,20 @@ namespace NintendoExtensionCtrl {
 		// The NES Mini controller reports itself as a Classic Controller
 		// and functions identically. This class includes data maps for
 		// the improperly reporting knockoff NES controllers
-		struct Maps : public ClassicController_Data::Maps {
+		struct Maps {
+			// Genuine maps, for reference
+			constexpr static BitMap  DpadUp = ClassicController_Data::Maps::DpadUp;
+			constexpr static BitMap  DpadDown = ClassicController_Data::Maps::DpadDown;
+			constexpr static BitMap  DpadLeft = ClassicController_Data::Maps::DpadLeft;
+			constexpr static BitMap  DpadRight = ClassicController_Data::Maps::DpadRight;
+
+			constexpr static BitMap  ButtonA = ClassicController_Data::Maps::ButtonA;
+			constexpr static BitMap  ButtonB = ClassicController_Data::Maps::ButtonB;
+
+			constexpr static BitMap  ButtonStart = ClassicController_Data::Maps::ButtonPlus;
+			constexpr static BitMap  ButtonSelect = ClassicController_Data::Maps::ButtonMinus;
+
+			// Knockoff maps
 			constexpr static BitMap  Knockoff_DpadUp = { 7, 0 };
 			constexpr static BitMap  Knockoff_DpadDown = { 6, 6 };
 			constexpr static BitMap  Knockoff_DpadLeft = { 7, 1 };

--- a/src/controllers/NESMiniController.h
+++ b/src/controllers/NESMiniController.h
@@ -27,6 +27,15 @@
 
 namespace NintendoExtensionCtrl {
 	class NESMiniController_Data : protected ClassicController_Data {
+	private:
+		typedef boolean(ClassicController_Data::*ClassicBoolean)(void) const;
+
+		template<ClassicBoolean func>
+		boolean knockoffButton(const ControlDataMap::BitMap map) const {
+			if (isKnockoff()) { return getControlBit(map); }
+			return (*this.*func)();
+		}
+
 	public:
 		// The NES Mini controller reports itself as a Classic Controller
 		// and functions identically. This class includes data maps for

--- a/src/controllers/NESMiniController.h
+++ b/src/controllers/NESMiniController.h
@@ -25,11 +25,46 @@
 
 #include "ClassicController.h"
 
-class NESMiniController : public ClassicController {
-public:
-	NESMiniController(NXC_I2C_TYPE& i2cBus = NXC_I2C_DEFAULT);
-	
-	void printDebug(Print& output=NXC_SERIAL_DEFAULT) const;
-};
+namespace NintendoExtensionCtrl {
+	class NESMiniController_Data : protected ClassicController_Data {
+	public:
+		// The NES Mini controller reports itself as a Classic Controller
+		// and functions identically. This class includes data maps for
+		// the improperly reporting knockoff NES controllers
+		struct Maps : public ClassicController_Data::Maps {
+			constexpr static BitMap  Knockoff_DpadUp = { 7, 0 };
+			constexpr static BitMap  Knockoff_DpadDown = { 6, 6 };
+			constexpr static BitMap  Knockoff_DpadLeft = { 7, 1 };
+			constexpr static BitMap  Knockoff_DpadRight = { 6, 7 };
+
+			constexpr static BitMap  Knockoff_ButtonStart = { 6, 2 };
+			constexpr static BitMap  Knockoff_ButtonSelect = { 6, 4 };
+
+			constexpr static BitMap  Knockoff_ButtonA = { 7, 4 };
+			constexpr static BitMap  Knockoff_ButtonB = { 7, 6 };
+		};
+
+		using ClassicController_Data::ClassicController_Data;  // Reuse constructor
+		using ClassicController_Data::id;  // Share ID
+
+		boolean dpadUp() const;
+		boolean dpadDown() const;
+		boolean dpadLeft() const;
+		boolean dpadRight() const;
+
+		boolean buttonA() const;
+		boolean buttonB() const;
+
+		boolean buttonStart() const;
+		boolean buttonSelect() const;
+
+		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
+
+		boolean isKnockoff() const;
+	};
+}
+
+typedef NintendoExtensionCtrl::BuildControllerClass
+	<NintendoExtensionCtrl::NESMiniController_Data>	NESMiniController;
 
 #endif


### PR DESCRIPTION
This pull request adds support for "knockoff" NES Mini controllers that incorrectly report their control data. See #33.

A genuine NES Mini controller functions identically to the Classic Controller. It has a matching identity string and reports its button data using the same mappings. I had a buddy try out the library with his controller, and this is what it reported with no buttons pressed:

```
Classic ____ | ___ | ____ L:(31, 31) R:(15, 15) | LT: 0_ RT: 0_ Z:__
Raw[8]: 0x5F | 0xDF | 0x8F | 0x00 | 0xFF | 0xFF | 0x00 | 0x00
```

On the other hand, a knockoff NES Mini controller does *not* function identically to the Classic Controller. It has the same identity string, but it reports its button presses using maps that are offset by two bytes (indices 6 and 7 instead of 4 and 5). Not only that, the data for the Classic Controller hardware that isn't present (analog sticks, triggers, etc.) is reported incorrectly:

```
Classic <^v> | -H+ | ABXY L:( 1,  1) R:(21,  1) | LT: 4X RT: 1X Z:LR
Raw[8]: 0x81 | 0x81 | 0x81 | 0x81 | 0x00 | 0x00 | 0xFF | 0xFF
```
Yikes.

To support the knockoff controllers, the code has to do two things:
1. Change the minimum number of control bytes requested from 6 to 8.
2. Use separate data maps when it thinks a knockoff controller is connected

Problem 1 was accomplished with pull request #34, that allows for user-specified variable request sizes and increases the maximum request size from 6 to 21. Although the user still has to explicitly increase the request size themselves.

Problem 2 is trickier, because I didn't want to hamstring the existing Classic Controller code by forcing every data call to check for a knockoff controller pattern, even if the user was only intending to use genuine controllers.

This PR is my solution. I rewrote the `NESMiniController` class to do just that: automatically switch between the genuine and knockoff data maps on each function call, depending on whether the first 6 bytes of the control data match the "incorrect" data reported above. This *shouldn't* ever result in a false positive, if only because the analog trigger values are in contradiction to the 'pressed' trigger buttons. It may however result in false negatives if the I²C data has errors.

---
There are some potential improvements to this implementation, but they come at a cost:

#### 1. Integrate this with the `ClassicController` class

One possible improvement is to create this sort of "knockoff" check automatically for each element in the `ClassicController` class, and do away with the separate `NESMinIController` definitions. At the moment I don't want to do that because it burdens the Classic Controller class with checks that it shouldn't *have* to do to function properly. And if the user is trying to mix controller types (Classic Controller and NES Mini) they should be knowledgeable enough to handle the control flow between class types or even build their own version of a mixed class.

#### 2. Automatically handle request size increase

The biggest hiccup in my mind to adding nicely integrated knockoff NES controller support is that the minimum request size has to increase from 6 bytes to 8. It's "only" a two byte increase, but at slow bus rates that can have a significant impact on your throughput. I *really* don't want to increase the default request size across the board because frankly no other controllers need it.

The library now supports user-set request sizes, so how do we deal with those? Would we override the user's set request size by increasing the size to 8 when an NES knockoff is detected? Then what do we do if they connect a different controller that only requires 6? Do we lower the request size? But what if *they* had set 8 by hand and need those two extra bytes? I could add another variable to keep track of the library's set size and the user's set size and compare them, but then that's extra memory and extra work just to try keeping things "automatic".

I think it's much better to put that control in the user's hands and let them decide whether to work around these broken controllers or not. For now changing the request size is sticky and requires an explicit function call.

#### 3. Integrate the knockoff support with `ExtensionController`

There's an alternative solution: rather than reworking our interpretation of the output values, intercept them and change them. That is, stuff some code into the `ExtensionController` class that, if the knockoff array values match, changes them to look "proper" to the `ClassicController class.

This is more efficient and cleaner to the end user, *but* it also bastardizes the separation between communication and interpretation that exists for the `ExtensionController` and `ControlDataMap` classes. It also adds bloat for every single controller, meaning that if you only use a Nunchuk you still have to do the processing as if you might connect to an NES Mini controller.

#### 4. Get things working "properly"

Somewhere in the world a company thought that these controllers worked fine and decided to sell them. From what I can see looking at reviews for 3rd party NES Mini controllers, most of them are reported to not work. *But*, there is likely some sort of middle ground - some group of settings or I²C requests that allows these controllers to communicate "properly" like a Classic Controller. I just have no idea what it is.

---

In the meantime, this implementation seems to do the trick to get both genuine and knockoff NES controllers working under the same roof without users having to modify the library internals. I'll take another look at improvements when the need arises.