### PR TITLE
DebugRaw tweaks and I2C speed example

### DIFF
--- a/examples/Any/SpeedTest/SpeedTest.ino
+++ b/examples/Any/SpeedTest/SpeedTest.ino
@@ -34,6 +34,9 @@ void setup() {
 	Serial.begin(115200);
 	controller.begin();
 
+	// Uncomment to run at 400 kHz (default is 100 kHz)
+	// controller.i2c.setClock(400000);  // 400 kHz "Fast" I2C
+
 	while (!controller.connect()) {
 		Serial.println("No controller detected!");
 		delay(1000);

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -122,5 +122,8 @@ void ExtensionController::printDebugRaw(Print& output) const {
 }
 
 void ExtensionController::printDebugRaw(uint8_t baseFormat, Print& output) const {
+	output.print("Raw[");
+	output.print(requestSize);
+	output.print("]: ");
 	printRaw(controlData, requestSize, baseFormat, output);
 }

--- a/src/internal/NXC_Utils.cpp
+++ b/src/internal/NXC_Utils.cpp
@@ -78,7 +78,7 @@ namespace NintendoExtensionCtrl {
 			output.print(dataOut, baseFormat);
 
 			if (i != dataSize - 1) {  // Print separators
-				output.print(" | ");
+				output.print(" ");
 			}
 		}
 		output.println();


### PR DESCRIPTION
Small, generic PR to include the request size and remove the separator from the `printDebugRaw` printout. This changes the `printDebugRaw` printout from this:
```
0x60 | 0xE0 | 0x91 | 0x42 | 0xFF | 0xFF
```

To this:
```
Raw[6]: 0x60 0xE0 0x91 0x42 0xFF 0xFF
```

The output tells you the # of bytes and is easier to cleanly separate for CSV purposes.

Also adds a 400 kHz option to the speed test example, for those looking to increase the I2C speed.