### PR TITLE
Public I2C Reference Function

### DIFF
--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -28,7 +28,7 @@ ExtensionController::ExtensionController(ExtensionData& dataRef)
 	: ExtensionController(dataRef, ExtensionType::AnyController) {}
 
 ExtensionController::ExtensionController(ExtensionData& dataRef, ExtensionType conID)
-	: i2c(dataRef.i2c), id(conID), data(dataRef)  {}
+	: id(conID), data(dataRef)  {}
 
 void ExtensionController::begin() {
 	data.i2c.begin();  // Initialize the bus
@@ -106,6 +106,10 @@ void ExtensionController::setRequestSize(size_t r) {
 	if (r >= MinRequestSize && r <= MaxRequestSize) {
 		requestSize = (uint8_t) r;
 	}
+}
+
+NXC_I2C_TYPE & ExtensionController::i2c() const {
+	return data.i2c;
 }
 
 void ExtensionController::printDebug(Print& output) const {

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -69,7 +69,7 @@ public:
 	static const uint8_t MinRequestSize = 6;   // Smallest reporting mode (0x37)
 	static const uint8_t MaxRequestSize = ExtensionData::ControlDataSize;
 
-	NXC_I2C_TYPE & i2c;  // Easily accessible I2C reference
+	NXC_I2C_TYPE & i2c() const;  // Easily accessible I2C reference
 	const ExtensionType id = ExtensionType::AnyController;
 
 protected:


### PR DESCRIPTION
Due to the structure rework, "dataRef" wasn't initialized when the reference for the public I2C member was bound to the `ExtensionController` class for templated controllers. This resulted in the reference being malformed and calls using it to cause uncaught exceptions.

I reworked this to be a function, which can only be called after the data member is initialized. Changes the public API slightly (now requires parentheses), but seems to fix the issue.