### PR TITLE
NES Third Party Controller Tweaks

### DIFF
--- a/examples/NES Mini/NES_DebugPrint/NES_DebugPrint.ino
+++ b/examples/NES Mini/NES_DebugPrint/NES_DebugPrint.ino
@@ -38,14 +38,14 @@ void setup() {
 		delay(1000);
 	}
 
-	if (nes.isKnockoff()) {  // Uh oh, looks like your controller isn't genuine?
-		nes.setRequestSize(8);  // Requires 8 or more bytes for knockoff controllers
+	if (nes.isThirdParty()) {  // Uh oh, looks like your controller isn't genuine?
+		nes.setRequestSize(8);  // Requires 8 or more bytes for third party controllers
 	}
 }
 
 void loop() {
 	boolean success = nes.update();  // Get new data from the controller
-	nes.fixKnockoffData();  // If knockoff, fix the data!
+	nes.fixThirdPartyData();  // If third party controller, fix the data!
 
 	if (success == true) {  // We've got data!
 		nes.printDebug();  // Print all of the values!

--- a/examples/NES Mini/NES_DebugPrint/NES_DebugPrint.ino
+++ b/examples/NES Mini/NES_DebugPrint/NES_DebugPrint.ino
@@ -45,9 +45,9 @@ void setup() {
 
 void loop() {
 	boolean success = nes.update();  // Get new data from the controller
-	nes.fixThirdPartyData();  // If third party controller, fix the data!
 
 	if (success == true) {  // We've got data!
+		nes.fixThirdPartyData();  // If third party controller, fix the data!
 		nes.printDebug();  // Print all of the values!
 	}
 	else {  // Data is bad :(

--- a/examples/NES Mini/NES_Demo/NES_Demo.ino
+++ b/examples/NES Mini/NES_Demo/NES_Demo.ino
@@ -37,8 +37,8 @@ void setup() {
 		delay(1000);
 	}
 
-	if (nes.isKnockoff()) {  // Uh oh, looks like your controller isn't genuine?
-		nes.setRequestSize(8);  // Requires 8 or more bytes for knockoff controllers
+	if (nes.isThirdParty()) {  // Uh oh, looks like your controller isn't genuine?
+		nes.setRequestSize(8);  // Requires 8 or more bytes for third party controllers
 	}
 }
 
@@ -46,7 +46,7 @@ void loop() {
 	Serial.println("----- NES Mini Controller Demo -----");  // Making things easier to read
 	
 	boolean success = nes.update();  // Get new data from the controller
-	nes.fixKnockoffData();  // If knockoff, fix the data!
+	nes.fixThirdPartyData();  // If third party controller, fix the data!
 
 	if (!success) {  // Ruh roh
 		Serial.println("Controller disconnected!");

--- a/examples/NES Mini/NES_Demo/NES_Demo.ino
+++ b/examples/NES Mini/NES_Demo/NES_Demo.ino
@@ -46,13 +46,15 @@ void loop() {
 	Serial.println("----- NES Mini Controller Demo -----");  // Making things easier to read
 	
 	boolean success = nes.update();  // Get new data from the controller
-	nes.fixThirdPartyData();  // If third party controller, fix the data!
 
 	if (!success) {  // Ruh roh
 		Serial.println("Controller disconnected!");
 		delay(1000);
 	}
 	else {
+		// If a third party controller is detected, fix the data!
+		nes.fixThirdPartyData();
+
 		// Read the DPAD (Up/Down/Left/Right)
 		boolean padUp = nes.dpadUp();
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -186,10 +186,10 @@ getNumTurntables	KEYWORD2
 
 ## NES Mini Controller
 # (Covered by the Classic Controller keywords)
-isNESKnockoff	KEYWORD2
-fixNESKnockoffData	KEYWORD2
-isKnockoff	KEYWORD2
-fixKnockoffData	KEYWORD2
+isNESThirdParty	KEYWORD2
+fixNESThirdPartyData	KEYWORD2
+isThirdParty	KEYWORD2
+fixThirdPartyData	KEYWORD2
 
 ## SNES Mini Controller
 # (Covered by the Classic Controller keywords)

--- a/keywords.txt
+++ b/keywords.txt
@@ -49,6 +49,7 @@ reset	KEYWORD2
 
 getControllerType	KEYWORD2
 getControlData	KEYWORD2
+getRequestSize	KEYWORD2
 
 setRequestSize	KEYWORD2
 

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -211,13 +211,34 @@ boolean ClassicController_Shared::isNESThirdParty() const {
 	// difficult if not impossible state for a normal Classic Controller to be in.
 	// Because of that, we can reasonably assume that if the bytes match this then the
 	// connected controller is a third party NES controller, and can be treated accordingly. 
+	//
+	// -------
+	//
+	// Issue #46 states that the 8BitDo Retro Receiver, another 3rd party controller,
+	// has a different set of data for the first six bytes:
+	//
+	//     0x84, 0x86, 0x86, 0x86, 0x00, 0x00
+	//
+	// This has been added in as a second conditional check.
+	//
+	// If any other 3rd party NES controllers have a different signature than these two,
+	// I'm going to modify this signature check to only check the last two bytes (4 & 5) as 0.
 
-	return getControlData(0) == 0x81 &&  // RX 4:3, LX
-	       getControlData(1) == 0x81 &&  // RX 2:1, LY
-	       getControlData(2) == 0x81 &&  // RX 0, LT 4:3, RY
-	       getControlData(3) == 0x81 &&  // LT 2:0, RT
-	       getControlData(4) == 0x00 &&  // Button packet 1 (all pressed)
-	       getControlData(5) == 0x00;    // Button packet 2 (all pressed)
+	       // 3rd Party Data Signature, Typical
+	return (getControlData(0) == 0x81 &&  // RX 4:3, LX
+	        getControlData(1) == 0x81 &&  // RX 2:1, LY
+	        getControlData(2) == 0x81 &&  // RX 0, LT 4:3, RY
+	        getControlData(3) == 0x81 &&  // LT 2:0, RT
+	        getControlData(4) == 0x00 &&  // Button packet 1 (all pressed)
+	        getControlData(5) == 0x00)    // Button packet 2 (all pressed)
+	||
+	       // 8BitDo Retro Receiver Signature
+	       (getControlData(0) == 0x84 &&  // RX 4:3, LX
+	        getControlData(1) == 0x86 &&  // RX 2:1, LY
+	        getControlData(2) == 0x86 &&  // RX 0, LT 4:3, RY
+	        getControlData(3) == 0x86 &&  // LT 2:0, RT
+	        getControlData(4) == 0x00 &&  // Button packet 1 (all pressed)
+	        getControlData(5) == 0x00);   // Button packet 2 (all pressed)
 }
 
 void ClassicController_Shared::manipulateThirdPartyData() {

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -183,10 +183,10 @@ void ClassicController_Shared::printDebug(Print& output) const {
 
 // ######### Mini Controller Support #########
 
-boolean ClassicController_Shared::fixNESThirdPartyData() {
+boolean ClassicController_Shared::fixNESThirdPartyData(boolean force) {
 	// Public-facing function to check and "correct" data if using a third party controller
 	// Returns 'true' if data was modified
-	if(isNESThirdParty() && getRequestSize() >= 8) {  // 8 is the minimum for valid data
+	if((isNESThirdParty() && getRequestSize() >= 8) || force == true) {  // 8 bytes is the minimum for valid data
 		manipulateThirdPartyData();
 		return true;
 	}

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -202,7 +202,7 @@ boolean ClassicController_Shared::isNESThirdParty() const {
 	// This is mostly garbage data that doesn't line up with the Classic Controller
 	// at all. Using the library's debug output, here is what it translates to:
 	//
-	//    <^v> | -H+ | ABXY L : (1, 1) R : (21, 1) | LT : 4X RT : 1X Z : LR
+	//    <^v> | -H+ | ABXY L:( 1,  1) R:(21,  1) | LT: 4X RT: 1X Z:LR
 	//
 	// You'll notice a few things. ALL possible buttons are pressed. The left analog 
 	// stick is completely down and to the left, while the right analog stick is down

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -186,7 +186,7 @@ void ClassicController_Shared::printDebug(Print& output) const {
 boolean ClassicController_Shared::fixNESThirdPartyData() {
 	// Public-facing function to check and "correct" data if using a third party controller
 	// Returns 'true' if data was modified
-	if(isNESThirdParty()) { 
+	if(isNESThirdParty() && getRequestSize() >= 8) {  // 8 is the minimum for valid data
 		manipulateThirdPartyData();
 		return true;
 	}

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -217,7 +217,11 @@ boolean ClassicController_Shared::isNESThirdParty() const {
 	// Issue #46 states that the 8BitDo Retro Receiver, another 3rd party controller,
 	// has a different set of data for the first six bytes:
 	//
-	//     0x84, 0x86, 0x86, 0x86, 0x00, 0x00
+	//    0x84, 0x86, 0x86, 0x86, 0x00, 0x00
+	//
+	// Which, again using the library's debug output, evaluates to:
+	//
+	//    <^v> | -H+ | ABXY L:( 4,  6) R:(21,  6) | LT: 4X RT: 6X Z:LR
 	//
 	// This has been added in as a second conditional check.
 	//

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -183,19 +183,19 @@ void ClassicController_Shared::printDebug(Print& output) const {
 
 // ######### Mini Controller Support #########
 
-boolean ClassicController_Shared::fixNESKnockoffData() {
-	// Public-facing function to check and "correct" data if using a knockoff
+boolean ClassicController_Shared::fixNESThirdPartyData() {
+	// Public-facing function to check and "correct" data if using a third party controller
 	// Returns 'true' if data was modified
-	if(isNESKnockoff()) { 
-		manipulateKnockoffData();
+	if(isNESThirdParty()) { 
+		manipulateThirdPartyData();
 		return true;
 	}
 	return false;
 }
 
-boolean ClassicController_Shared::isNESKnockoff() const {
-	// The NES knockoffs I've come across seem to display the same unchanging pattern
-	// for the first six control bytes:
+boolean ClassicController_Shared::isNESThirdParty() const {
+	// The third party NES controllers I've come across seem to display the same
+	// unchanging pattern for the first six control bytes:
 	//
 	//     0x81, 0x81, 0x81, 0x81, 0x00, 0x00
 	//
@@ -210,7 +210,7 @@ boolean ClassicController_Shared::isNESKnockoff() const {
 	// down, and yet the analog trigger values are very low. In short, this is a
 	// difficult if not impossible state for a normal Classic Controller to be in.
 	// Because of that, we can reasonably assume that if the bytes match this then the
-	// connected controller is an NES Knockoff, and can be treated accordingly. 
+	// connected controller is a third party NES controller, and can be treated accordingly. 
 
 	return getControlData(0) == 0x81 &&  // RX 4:3, LX
 	       getControlData(1) == 0x81 &&  // RX 2:1, LY
@@ -220,8 +220,8 @@ boolean ClassicController_Shared::isNESKnockoff() const {
 	       getControlData(5) == 0x00;    // Button packet 2 (all pressed)
 }
 
-void ClassicController_Shared::manipulateKnockoffData() {
-	// The data returned by knockoff NES controllers for the missing control surfaces
+void ClassicController_Shared::manipulateThirdPartyData() {
+	// The data returned by third party NES controllers for the missing control surfaces
 	// (joysticks, triggers, etc.) is "corrupted", meaning that it doesn't align with
 	// what you would expect a Classic Controller at rest to display.
 	//
@@ -237,9 +237,9 @@ void ClassicController_Shared::manipulateKnockoffData() {
 	// The left joystick is centered at 31/31, the right joystick is centered at 15/15,
 	// the analog trigger values are 0, and all buttons are released.
 	//
-	// For the NES Mini knockoffs, only the two data packets containing the button booleans
-	// matter. Bytes 0, 1, 2, and 3 (joysticks and triggers) are replaced entirely. Bytes
-	// 4 and 5 are overridden by the values in 6 and 7.
+	// For the third party NES Mini controllers, only the two data packets containing the button
+	// booleans matter. Bytes 0, 1, 2, and 3 (joysticks and triggers) are replaced entirely.
+	// Bytes 4 and 5 are overridden by the values in 6 and 7.
 
 	setControlData(0, 0x5F);
 	setControlData(1, 0xDF);

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -99,21 +99,21 @@ namespace NintendoExtensionCtrl {
 
 		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 
-	// NES Knockoff Support
+	// 3rd Party NES Controller Support
 	public:
-		boolean isNESKnockoff() const;
-		boolean fixNESKnockoffData();
+		boolean isNESThirdParty() const;
+		boolean fixNESThirdPartyData();
 
 	protected:
-		void manipulateKnockoffData();
+		void manipulateThirdPartyData();
 	};
 
 	class NESMiniController_Shared : public ClassicController_Shared {
 	public:
 		using ClassicController_Shared::ClassicController_Shared;
 
-		boolean isKnockoff() const { return isNESKnockoff(); }
-		boolean fixKnockoffData() { return fixNESKnockoffData(); }
+		boolean isThirdParty() const { return isNESThirdParty(); }
+		boolean fixThirdPartyData() { return fixNESThirdPartyData(); }
 
 		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 	};

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -102,7 +102,7 @@ namespace NintendoExtensionCtrl {
 	// 3rd Party NES Controller Support
 	public:
 		boolean isNESThirdParty() const;
-		boolean fixNESThirdPartyData();
+		boolean fixNESThirdPartyData(boolean force = false);
 
 	protected:
 		void manipulateThirdPartyData();
@@ -113,7 +113,7 @@ namespace NintendoExtensionCtrl {
 		using ClassicController_Shared::ClassicController_Shared;
 
 		boolean isThirdParty() const { return isNESThirdParty(); }
-		boolean fixThirdPartyData() { return fixNESThirdPartyData(); }
+		boolean fixThirdPartyData(boolean force = false) { return fixNESThirdPartyData(force); }
 
 		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 	};

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -102,6 +102,10 @@ ExtensionController::ExtensionData & ExtensionController::getExtensionData() con
 	return data;
 }
 
+size_t ExtensionController::getRequestSize() const {
+	return requestSize;
+}
+
 void ExtensionController::setRequestSize(size_t r) {
 	if (r >= MinRequestSize && r <= MaxRequestSize) {
 		requestSize = (uint8_t) r;

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -58,6 +58,7 @@ public:
 	ExtensionType getControllerType() const;
 	uint8_t getControlData(uint8_t controlIndex) const;
 	ExtensionData & getExtensionData() const;
+	size_t getRequestSize() const;
 
 	void setRequestSize(size_t size = MinRequestSize);
 


### PR DESCRIPTION
Small pull request to change some behavior of third party NES controllers. Starting with, you know, changing what I used to call "knockoffs" to "third party" controllers.

* Refactor `isKnockoff` and `fixKnockoffData` to `isThirdParty` and `fixThirdPartyData` respectively. The new names are a little long, but I can't think of a good alternative.
* Within the examples, put the NES third party 'fix' function inside the success block. This was an oversight from before.
* Added a `getRequestSize` function for all controllers, now that the request size is variable it can be useful to check it.
* Speaking of... the NES 'fix' function now checks if the request size is 8 or larger before trying to move data from that portion of the array into the lower indices.
* The `isKnockoff` function now checks for the identity of the 8BitDo wireless receiver, which presents with a different set of ID bytes than most other third party controllers (#46)
* To avoid future issues with other third party NES controllers that may have mismatched ID bytes, the `fixThirdPartyData` function now takes a boolean argument to override the third party ID check. This will forcibly move data from indices 6 and 7 into the lower bytes. If the controller is not a third party NES, or if the request size has not been increased to 8 or above, this will corrupt the update data. User beware.