### PR TITLE
Unsigned DJ Crossfade

### DIFF
--- a/examples/DJ/DJ_Demo/DJ_Demo.ino
+++ b/examples/DJ/DJ_Demo/DJ_Demo.ino
@@ -108,15 +108,15 @@ void loop() {
 		Serial.print("The effect dial is at ");
 		Serial.println(fx);
 
-		// Read the crossfade slider (-8-7, negative to the left)
+		// Read the crossfade slider (0-15, left to right)
 		int cross = dj.crossfadeSlider();
 
 		Serial.print("The crossfade slider is ");
 
-		if (cross <= -2) {
+		if (cross <= 6) {
 			Serial.println("left");
 		}
-		else if (cross >= 1) {
+		else if (cross >= 9) {
 			Serial.println("right");
 		}
 		else {

--- a/examples/DJ/DJ_Demo/DJ_Demo.ino
+++ b/examples/DJ/DJ_Demo/DJ_Demo.ino
@@ -48,7 +48,7 @@ void loop() {
 		delay(1000);
 	}
 	else {
-		// Read the turntable, basic (-30-29. Clockwise = positive, faster = larger)
+		// Read the turntable, basic (-30-29. Clockwise = positive, faster = larger). ~900 ticks per revolution.
 		int turntable = dj.turntable();
 
 		Serial.print("The turntable is ");

--- a/examples/DJ/DJ_Demo/DJ_Demo.ino
+++ b/examples/DJ/DJ_Demo/DJ_Demo.ino
@@ -120,7 +120,7 @@ void loop() {
 			Serial.println("right");
 		}
 		else {
-			Serial.println("center");
+			Serial.println("centered");
 		}
 
 		// Read the joystick axis (0-63 XY)

--- a/src/controllers/DJTurntable.cpp
+++ b/src/controllers/DJTurntable.cpp
@@ -69,8 +69,8 @@ uint8_t DJTurntableController_Shared::effectDial() const {
 	return getControlData(Maps::EffectDial);
 }
 
-int8_t DJTurntableController_Shared::crossfadeSlider() const {
-	return getControlData(Maps::CrossfadeSlider) - 8;  // Shifted to signed int
+uint8_t DJTurntableController_Shared::crossfadeSlider() const {
+	return getControlData(Maps::CrossfadeSlider);
 }
 
 boolean DJTurntableController_Shared::buttonEuphoria() const {
@@ -154,7 +154,7 @@ void DJTurntableController_Shared::printDebug(Print& output) {
 	char euphoriaPrint = buttonEuphoria() ? 'E' : fillCharacter;
 
 	sprintf(buffer,
-		" Joy:(%2u, %2u) | %c | %c%c | FX: %2u | Fade: %2d",
+		" Joy:(%2u, %2u) | %c | %c%c | FX: %2u | Fade: %2u",
 		joyX(), joyY(),
 		euphoriaPrint,
 		minusPrint, plusPrint,

--- a/src/controllers/DJTurntable.h
+++ b/src/controllers/DJTurntable.h
@@ -68,7 +68,7 @@ namespace NintendoExtensionCtrl {
 			Both,
 		};
 
-		int8_t turntable() const;  // 6 bits, -30-29. Clockwise = positive, faster = larger.
+		int8_t turntable() const;  // 6 bits, -30-29. Clockwise = positive, faster = larger. ~900 ticks per revolution.
 
 		boolean buttonGreen() const;
 		boolean buttonRed() const;

--- a/src/controllers/DJTurntable.h
+++ b/src/controllers/DJTurntable.h
@@ -75,7 +75,7 @@ namespace NintendoExtensionCtrl {
 		boolean buttonBlue() const;
 
 		uint8_t effectDial() const;  // 5 bits, 0-31. One rotation per rollover.
-		int8_t crossfadeSlider() const;  // 4 bits, -8-7. Negative to the left.
+		uint8_t crossfadeSlider() const;  // 4 bits, 0-15. Left to right.
 
 		boolean buttonEuphoria() const;
 


### PR DESCRIPTION
Small pull request to change the behavior of the DJ Hero turntable's `crossfadeSlider` function to report an unsigned value (0-15) instead of a signed one (-8-7).

This is the only control surface function in the library that reports something *other* than the raw data out of the controller. This change makes the crossfade slider consistent with all of the other controls in both type (unsigned byte) and behavior. Plus the signed version has a ["two zeroes" problem](https://en.wikipedia.org/wiki/Signed_zero) where the detent can register as either '0' or '-1' depending on the controller, which is potentially confusing to the user.

This PR also tweaks the DJ `demo` example to fix a grammar error, and adds a comment to note that there are approximately 900 "ticks" per revolution of the turntable. Fun fact! And useful.