### PR TITLE
Add 2.4ghz SNES Classic Support... needs deliberation

### DIFF
--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -226,7 +226,10 @@ boolean ClassicController_Shared::isNESThirdParty() const {
 	// This has been added in as a second conditional check.
 	//
 	// If any other 3rd party NES controllers have a different signature than these two,
-	// I'm going to modify this signature check to only check the last two bytes (4 & 5) as 0.
+	// I'm going to modify this signature check to only check the last two bytes (4 & 5) as 0. - dmadison
+    // ---
+    // That might not be possible, as *some* controllers (for some godforsaken reason),
+    // put "trigger" data in those bytes, causing the isNESThirdParty check to fail. - nullstalgia
 
 	       // 3rd Party Data Signature, Typical
 	return (getControlData(0) == 0x81 &&  // RX 4:3, LX
@@ -242,7 +245,14 @@ boolean ClassicController_Shared::isNESThirdParty() const {
 	        getControlData(2) == 0x86 &&  // RX 0, LT 4:3, RY
 	        getControlData(3) == 0x86 &&  // LT 2:0, RT
 	        getControlData(4) == 0x00 &&  // Button packet 1 (all pressed)
-	        getControlData(5) == 0x00);   // Button packet 2 (all pressed)
+	        getControlData(5) == 0x00)   // Button packet 2 (all pressed)
+    ||
+           // 2.4ghz "SNES Classic" Controller Signature
+           (getControlData(0) == 0x83 &&  // RX 4:3, LX
+	        getControlData(1) == 0x85 &&  // RX 2:1, LY
+	        getControlData(2) == 0x85 &&  // RX 0, LT 4:3, RY
+	        getControlData(3) == 0x85);   // Button packet 2 (all pressed)
+
 }
 
 void ClassicController_Shared::manipulateThirdPartyData() {

--- a/src/internal/NXC_Identity.h
+++ b/src/internal/NXC_Identity.h
@@ -49,6 +49,11 @@ namespace NintendoExtensionCtrl {
 				return ExtensionType::ClassicController;
 			}
 
+            // 3rd Party 2.4ghz SNES Controller Con. ID: 0x0301
+			else if (idData[4] == 0x03 && idData[5] == 0x01) {
+                return ExtensionType::ClassicController;
+            } 
+            
 			// Guitar Hero Controllers: 0x##00, 0xA420, 0x0103
 			else if (idData[1] == 0x00
 				&& idData[4] == 0x01 && idData[5] == 0x03) {


### PR DESCRIPTION
Hi, me again :eyes: 

So I grabbed [these off Amazon](https://www.amazon.com/gp/product/B07FCXL2VV/ref=ppx_yo_dt_b_asin_title_o00_s00?ie=UTF8&psc=1), and they are a MESS.

Trigger data is in Control Bytes 4 and 5, they have a weird ID, etc

So you *can* merge this if you like, but I'm not too sure.


Additionally, you may remember issue #46 of mine. I contacted 8BitDo about adding analog stick support to the adapter, and they may consider it.

The reason I bring it up, is because of how ManipulateThirdPartyData forces a set state of analogs, and this controller does its own BS...

I'll keep you updated. :)