### PR TITLE
Drawsome Tablet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,7 @@ script:
   - buildExampleFolder Nunchuk
   - buildExampleFolder "SNES Mini"
   - buildExampleFolder "uDraw Tablet"
+  - buildExampleFolder "Drawsome Tablet"
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -28,10 +28,15 @@ Plug in your controller, upload the example to your board, and have fun!
 ### Wii
 * Nunchuk
 * Classic Controller
+
+### Wii Instruments
 * Guitar Hero Guitar
 * Guitar Hero World Tour Drums
 * DJ Hero Turntable
+
+### Wii Drawing Tablets
 * uDraw Tablet
+* Drawsome Tablet
 
 ### Mini Console
 * NES Mini Controller

--- a/examples/Drawsome Tablet/Drawsome_DebugPrint/Drawsome_DebugPrint.ino
+++ b/examples/Drawsome Tablet/Drawsome_DebugPrint/Drawsome_DebugPrint.ino
@@ -1,6 +1,6 @@
 /*
 *  Project     Nintendo Extension Controller Library
-*  @author     David Madison
+*  @author     nullstalgia
 *  @link       github.com/dmadison/NintendoExtensionCtrl
 *  @license    LGPLv3 - Copyright (c) 2018 David Madison
 *
@@ -18,24 +18,35 @@
 *
 *  You should have received a copy of the GNU Lesser General Public License
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*  Example:      Drawsome_DebugPrint
+*  Description:  Connect to a Drawsome Tablet and continuously print
+*                its control data, nicely formatted for debugging, over
+*                the serial bus.
 */
 
-#ifndef NintendoExtensionCtrl_h
-#define NintendoExtensionCtrl_h
+#include <NintendoExtensionCtrl.h>
 
-// Controller Base
-#include "internal/ExtensionController.h"
+DrawsomeTablet tablet;
 
-// Wii Controllers
-#include "controllers/Nunchuk.h"
-#include "controllers/ClassicController.h"
-#include "controllers/GuitarController.h"
-#include "controllers/DrumController.h"
-#include "controllers/DJTurntable.h"
-#include "controllers/uDrawTablet.h"
-#include "controllers/DrawsomeTablet.h"
+void setup() {
+	Serial.begin(115200);
+	tablet.begin();
 
-// Mini Controllers
-/* (included with ClassicController.h) */
+	while (!tablet.connect()) {
+		Serial.println("Drawsome Tablet not detected!");
+		delay(1000);
+	}
+}
 
-#endif
+void loop() {
+	boolean success = tablet.update();  // Get new data from the tablet
+
+	if (success == true) {  // We've got data!
+		tablet.printDebug();  // Print all of the values!
+	}
+	else {  // Data is bad :(
+		Serial.println("Tablet Disconnected!");
+		tablet.reconnect();
+	}
+}

--- a/examples/Drawsome Tablet/Drawsome_DebugPrint/Drawsome_DebugPrint.ino
+++ b/examples/Drawsome Tablet/Drawsome_DebugPrint/Drawsome_DebugPrint.ino
@@ -47,6 +47,7 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Tablet Disconnected!");
-		tablet.reconnect();
+		delay(1000);
+		tablet.connect();
 	}
 }

--- a/examples/Drawsome Tablet/Drawsome_Demo/Drawsome_Demo.ino
+++ b/examples/Drawsome Tablet/Drawsome_Demo/Drawsome_Demo.ino
@@ -55,12 +55,12 @@ void loop() {
 		if (detected == true) {
 			Serial.print("The pen is detected! It's currently at ");
 
-			// Read the X/Y coordinates (0-4095)
-			int xCoordinate = tablet.penX();
+			// Read the X/Y coordinates (0-65535)
+			uint16_t xCoordinate = tablet.penX();
 			Serial.print("X: ");
 			Serial.print(xCoordinate);
 
-			int yCoordinate = tablet.penY();
+			uint16_t yCoordinate = tablet.penY();
 			Serial.print(" Y: ");
 			Serial.print(yCoordinate);
 
@@ -70,8 +70,8 @@ void loop() {
 			Serial.println("The pen is too far away!");
 		}
 
-		// Read the Pressure (0-511)
-		int pressure = tablet.penPressure();
+		// Read the Pressure (0-4095)
+		uint16_t pressure = tablet.penPressure();
 
 		Serial.print("The current pressure is ");
 		Serial.println(pressure);

--- a/examples/Drawsome Tablet/Drawsome_Demo/Drawsome_Demo.ino
+++ b/examples/Drawsome Tablet/Drawsome_Demo/Drawsome_Demo.ino
@@ -46,7 +46,7 @@ void loop() {
 	if (!success) {  // Ruh roh
 		Serial.println("Controller disconnected!");
 		delay(1000);
-		tablet.reconnect();
+		tablet.connect();
 	}
 	else {
 		// Is the pen near the drawing surface?

--- a/examples/Drawsome Tablet/Drawsome_Demo/Drawsome_Demo.ino
+++ b/examples/Drawsome Tablet/Drawsome_Demo/Drawsome_Demo.ino
@@ -1,0 +1,83 @@
+/*
+*  Project     Nintendo Extension Controller Library
+*  @author     nullstalgia
+*  @link       github.com/dmadison/NintendoExtensionCtrl
+*  @license    LGPLv3 - Copyright (c) 2018 David Madison
+*
+*  This file is part of the Nintendo Extension Controller Library.
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Lesser General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Lesser General Public License for more details.
+*
+*  You should have received a copy of the GNU Lesser General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*  Example:      Drawsome_Demo
+*  Description:  Connect to a Drawsome Tablet and demonstrate all of
+*                the avaiable control data functions.
+*/
+
+#include <NintendoExtensionCtrl.h>
+
+DrawsomeTablet tablet;
+
+void setup() {
+	Serial.begin(115200);
+	tablet.begin();
+
+	while (!tablet.connect()) {
+		Serial.println("Drawsome Tablet not detected!");
+		delay(1000);
+	}
+}
+
+void loop() {
+	Serial.println("----- Drawsome Tablet Demo -----");  // Making things easier to read
+	
+	boolean success = tablet.update();  // Get new data from the tablet
+
+	if (!success) {  // Ruh roh
+		Serial.println("Controller disconnected!");
+		delay(1000);
+		tablet.reconnect();
+	}
+	else {
+		// Is the pen near the drawing surface?
+		boolean detected = tablet.penDetected();
+
+		if (detected == true) {
+			Serial.print("The pen is detected! It's currently at ");
+
+			// Read the X/Y coordinates (0-4095)
+			int xCoordinate = tablet.penX();
+			Serial.print("X: ");
+			Serial.print(xCoordinate);
+
+			int yCoordinate = tablet.penY();
+			Serial.print(" Y: ");
+			Serial.print(yCoordinate);
+
+			Serial.println();
+		}
+		else if (detected == false) {
+			Serial.println("The pen is too far away!");
+		}
+
+		// Read the Pressure (0-511)
+		int pressure = tablet.penPressure();
+
+		Serial.print("The current pressure is ");
+		Serial.println(pressure);
+
+		// Print all the values!
+		tablet.printDebug();
+		delay(100);
+	}
+}

--- a/src/controllers/DrawsomeTablet.cpp
+++ b/src/controllers/DrawsomeTablet.cpp
@@ -36,7 +36,7 @@ constexpr BitMap      DrawsomeTablet_Shared::Maps::Pen_Detected;
 
 boolean DrawsomeTablet_Shared::specificInit() {
 	/* Two necessary register writes during initialization before the tablet
-	 * before the tablet will start sending data. See this for reference:
+	 * will start sending data. See this for reference:
 	 * https://www.raphnet.net/divers/wii_graphics_tablets/index_en.php
 	 */
 	return writeRegister(0xFB, 0x01) && writeRegister(0xF0, 0x55);

--- a/src/controllers/DrawsomeTablet.cpp
+++ b/src/controllers/DrawsomeTablet.cpp
@@ -57,7 +57,7 @@ void DrawsomeTablet_Shared::printDebug(Print& output) const {
 
 	output.print("DrawsomeTablet - ");
 	sprintf(buffer,
-		"Pen:(%6u, %6u) | Pressure:%3u | Pen Detect:%c",
+		"Pen:(%6u, %6u) | Pressure:%4u | Pen Detect:%c",
 			penX(), penY(), penPressure(), penPrint);
 
 	output.println(buffer);

--- a/src/controllers/DrawsomeTablet.cpp
+++ b/src/controllers/DrawsomeTablet.cpp
@@ -1,0 +1,66 @@
+/*
+*  Project     Nintendo Extension Controller Library
+*  @author     nullstalgia
+*  @link       github.com/dmadison/NintendoExtensionCtrl
+*  @license    LGPLv3 - Copyright (c) 2018 David Madison
+*
+*  This file is part of the Nintendo Extension Controller Library.
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Lesser General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Lesser General Public License for more details.
+*
+*  You should have received a copy of the GNU Lesser General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "DrawsomeTablet.h"
+
+namespace NintendoExtensionCtrl {
+
+constexpr CtrlIndex   DrawsomeTablet_Shared::Maps::PenX_LSB;
+constexpr CtrlIndex   DrawsomeTablet_Shared::Maps::PenX_MSB;
+constexpr CtrlIndex   DrawsomeTablet_Shared::Maps::PenY_LSB;
+constexpr CtrlIndex   DrawsomeTablet_Shared::Maps::PenY_MSB;
+
+constexpr CtrlIndex   DrawsomeTablet_Shared::Maps::Pressure_LSB;
+constexpr ByteMap     DrawsomeTablet_Shared::Maps::Pressure_MSB;
+
+constexpr BitMap      DrawsomeTablet_Shared::Maps::Pen_Detected;
+
+uint16_t DrawsomeTablet_Shared::penX() const {
+	return (getControlData(Maps::PenX_MSB) << 8) | getControlData(Maps::PenX_LSB);
+}
+
+uint16_t DrawsomeTablet_Shared::penY() const {
+	return (getControlData(Maps::PenY_MSB) << 8) | getControlData(Maps::PenY_LSB);
+}
+
+uint16_t DrawsomeTablet_Shared::penPressure() const {
+	return (getControlData(Maps::Pressure_MSB) << 8) | getControlData(Maps::Pressure_LSB);
+}
+
+boolean DrawsomeTablet_Shared::penDetected() const {
+	return getControlBit(Maps::Pen_Detected);
+}
+
+void DrawsomeTablet_Shared::printDebug(Print& output) const {
+	char buffer[60];
+	
+	char penPrint = penDetected() ? 'Y' : 'N';
+
+	output.print("DrawsomeTablet - ");
+	sprintf(buffer,
+		"Pen:(%6u, %6u) | Pressure:%3u | Pen Detect:%c",
+			penX(), penY(), penPressure(), penPrint);
+
+	output.println(buffer);
+}
+
+}  // End "NintendoExtensionCtrl" namespace

--- a/src/controllers/DrawsomeTablet.cpp
+++ b/src/controllers/DrawsomeTablet.cpp
@@ -34,6 +34,14 @@ constexpr ByteMap     DrawsomeTablet_Shared::Maps::Pressure_MSB;
 
 constexpr BitMap      DrawsomeTablet_Shared::Maps::Pen_Detected;
 
+boolean DrawsomeTablet_Shared::specificInit() {
+	/* Two necessary register writes during initialization before the tablet
+	 * before the tablet will start sending data. See this for reference:
+	 * https://www.raphnet.net/divers/wii_graphics_tablets/index_en.php
+	 */
+	return writeRegister(0xFB, 0x01) && writeRegister(0xF0, 0x55);
+}
+
 uint16_t DrawsomeTablet_Shared::penX() const {
 	return (getControlData(Maps::PenX_MSB) << 8) | getControlData(Maps::PenX_LSB);
 }

--- a/src/controllers/DrawsomeTablet.h
+++ b/src/controllers/DrawsomeTablet.h
@@ -1,6 +1,6 @@
 /*
 *  Project     Nintendo Extension Controller Library
-*  @author     nullstalgia	
+*  @author     nullstalgia
 *  @link       github.com/dmadison/NintendoExtensionCtrl
 *  @license    LGPLv3 - Copyright (c) 2018 David Madison
 *
@@ -46,6 +46,8 @@ namespace NintendoExtensionCtrl {
 
 		DrawsomeTablet_Shared(ExtensionPort &port) :
 			DrawsomeTablet_Shared(port.getExtensionData()) {}
+
+		boolean specificInit();  // for required register writes at init
 
 		uint16_t penX() const;  // 16 bits, 0-65535
 		uint16_t penY() const;

--- a/src/controllers/DrawsomeTablet.h
+++ b/src/controllers/DrawsomeTablet.h
@@ -1,0 +1,64 @@
+/*
+*  Project     Nintendo Extension Controller Library
+*  @author     nullstalgia	
+*  @link       github.com/dmadison/NintendoExtensionCtrl
+*  @license    LGPLv3 - Copyright (c) 2018 David Madison
+*
+*  This file is part of the Nintendo Extension Controller Library.
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Lesser General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Lesser General Public License for more details.
+*
+*  You should have received a copy of the GNU Lesser General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NXC_DrawsomeTablet_h
+#define NXC_DrawsomeTablet_h
+
+#include "internal/ExtensionController.h"
+
+namespace NintendoExtensionCtrl {
+	class DrawsomeTablet_Shared : public ExtensionController {
+	public:
+		struct Maps {
+			constexpr static CtrlIndex PenX_LSB = 0;
+			constexpr static CtrlIndex PenX_MSB = 1;
+            
+			constexpr static CtrlIndex PenY_LSB = 2;
+			constexpr static CtrlIndex PenY_MSB = 3;
+
+			constexpr static CtrlIndex Pressure_LSB = 4;
+			constexpr static ByteMap   Pressure_MSB = ByteMap(5, 4, 0, 0);
+
+			constexpr static BitMap    Pen_Detected = {5, 7};
+		};
+		
+		DrawsomeTablet_Shared(ExtensionData &dataRef) :
+			ExtensionController(dataRef, ExtensionType::DrawsomeTablet) {}
+
+		DrawsomeTablet_Shared(ExtensionPort &port) :
+			DrawsomeTablet_Shared(port.getExtensionData()) {}
+
+		uint16_t penX() const;  // 16 bits, 0-65535
+		uint16_t penY() const;
+
+		uint16_t penPressure() const;  // 12 bits, 0-4095
+
+		boolean  penDetected() const;
+
+		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
+	};
+}
+
+using DrawsomeTablet = NintendoExtensionCtrl::BuildControllerClass
+	<NintendoExtensionCtrl::DrawsomeTablet_Shared>;
+
+#endif

--- a/src/internal/NXC_Identity.h
+++ b/src/internal/NXC_Identity.h
@@ -34,7 +34,8 @@ enum class ExtensionType {
 	GuitarController,
 	DrumController,
 	DJTurntableController,
-	uDrawTablet
+	uDrawTablet,
+	DrawsomeTablet
 };
 
 namespace NintendoExtensionCtrl {
@@ -70,6 +71,10 @@ namespace NintendoExtensionCtrl {
 			// uDraw Tablet Con. ID: 0x0112
 			else if (idData[4] == 0x01 && idData[5] == 0x12) {
 				return ExtensionType::uDrawTablet;
+			}
+			// Drawsome Tablet Con. ID: 0x0013
+			else if (idData[4] == 0x00 && idData[5] == 0x13) {
+				return ExtensionType::DrawsomeTablet;
 			}
 		}
 


### PR DESCRIPTION
So, it's quite a bit simpler than the uDraw, but I think I prefer it... minus the magic address writing that has to be done.

Anyway, this is tested and working so far. 

(Tested with this added to `NXC_Comms.h`
```cpp
// Extension controller specific I2C functions
// -------------------------------------------
// Control Data
inline boolean initialize(NXC_I2C_TYPE &i2c) {
	/* Initialization for unencrypted communication.
	* *Should* work on all devices, genuine + 3rd party.
	* See http://wiibrew.org/wiki/Wiimote/Extension_Controllers
	*/
	if (!i2c_writeRegister(i2c, I2C_Addr, 0xF0, 0x55)) { return false; }
	delay(10);
	if (!i2c_writeRegister(i2c, I2C_Addr, 0xFB, 0x00)) { return false; }
	delay(20);
	if (!i2c_writeRegister(i2c, I2C_Addr, 0xFB, 0x01)) { return false; }
	delay(10);
	if (!i2c_writeRegister(i2c, I2C_Addr, 0xF0, 0x55)) { return false; }
	delay(20);
	return true;
}
```
)

---

Some notes:

`1.` The X and Y mapping they use is different. 

![image](https://user-images.githubusercontent.com/20761757/77248995-406bee80-6bfb-11ea-902a-f162f3a0121e.png)
![image](https://user-images.githubusercontent.com/20761757/77249008-5679af00-6bfb-11ea-9843-c18c03d3fb22.png)

(Photos from Raphnet)

Y is flipped.

`2.` When the pen is off the surface, uDraw sets it to an impossible value. Drawsome leaves at at previous.

`3.` Neither tablet uses the whole range of the allocated bytes given for pressure/x/y, etc. Should we document this somewhere, using the values provided by raphnet/our own testing?