### PR TITLE
Static Comms and Controller-Specific Init

### DIFF
--- a/examples/Any/DebugPrint/DebugPrint.ino
+++ b/examples/Any/DebugPrint/DebugPrint.ino
@@ -46,6 +46,7 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
+		delay(1000);
 		controller.connect();
 	}
 }

--- a/examples/Any/DebugPrint/DebugPrint.ino
+++ b/examples/Any/DebugPrint/DebugPrint.ino
@@ -46,6 +46,6 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
-		controller.reconnect();
+		controller.connect();
 	}
 }

--- a/examples/Any/MultipleTypes/MultipleTypes.ino
+++ b/examples/Any/MultipleTypes/MultipleTypes.ino
@@ -31,11 +31,33 @@ ExtensionPort port;  // Port for communicating with extension controllers
 Nunchuk::Shared nchuk(port);  // Read Nunchuk formatted data from the port
 ClassicController::Shared classic(port);  // Read Classic Controller formatted data from the port
 
+ExtensionController * controllers[] = {  // Array of available controllers, for controller-specific init
+	&nchuk,
+	&classic,
+};
+const int NumControllers = sizeof(controllers) / sizeof(ExtensionController*);  // # of controllers, auto-generated
+
+
+boolean connectController() {
+	boolean connected = port.connect();  // Connect to the controller
+
+	if (connected == true) {
+		for (int i = 0; i < NumControllers; i++) {
+			if (controllers[i]->controllerTypeMatches()) {  // If this controller is connected...
+				connected = controllers[i]->specificInit();  // ...run the controller-specific initialization
+				break;
+			}
+		}
+	}
+
+	return connected;
+}
+
 void setup() {
 	Serial.begin(115200);
-	port.begin();
+	port.begin();  // init I2C
 
-	while (!port.connect()) {
+	while (!connectController()) {
 		Serial.println("No controller found!");
 		delay(1000);
 	}
@@ -56,15 +78,12 @@ void loop() {
 				break;
 			default:
 				Serial.println("Other controller connected!");
-				quit();
 		}
 	}
 	else {  // Data is bad :(
-		Serial.println("Controller Disconnected!");
-		quit();
+		while (!connectController()) {
+			Serial.println("Controller Disconnected!");
+			delay(1000);
+		}
 	}
-}
-
-void quit() {
-	while (true) {}  // Infinite loop
 }

--- a/examples/Any/SpeedTest/SpeedTest.ino
+++ b/examples/Any/SpeedTest/SpeedTest.ino
@@ -58,7 +58,7 @@ void loop() {
 	if (!validData) {
 		Serial.println("ERROR! Invalid data received!");
 
-		while (!controller.reconnect()) {
+		while (!controller.connect()) {
 			Serial.println("Attempting to reconnect...");
 			delay(1000);
 		}

--- a/examples/Classic Controller/Classic_DebugPrint/Classic_DebugPrint.ino
+++ b/examples/Classic Controller/Classic_DebugPrint/Classic_DebugPrint.ino
@@ -47,6 +47,7 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
+		delay(1000);
 		classic.connect();
 	}
 }

--- a/examples/Classic Controller/Classic_DebugPrint/Classic_DebugPrint.ino
+++ b/examples/Classic Controller/Classic_DebugPrint/Classic_DebugPrint.ino
@@ -47,6 +47,6 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
-		classic.reconnect();
+		classic.connect();
 	}
 }

--- a/examples/DJ/DJ_DebugPrint/DJ_DebugPrint.ino
+++ b/examples/DJ/DJ_DebugPrint/DJ_DebugPrint.ino
@@ -47,6 +47,7 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
+		delay(1000);
 		dj.connect();
 	}
 }

--- a/examples/DJ/DJ_DebugPrint/DJ_DebugPrint.ino
+++ b/examples/DJ/DJ_DebugPrint/DJ_DebugPrint.ino
@@ -47,6 +47,6 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
-		dj.reconnect();
+		dj.connect();
 	}
 }

--- a/examples/DJ/DJ_EffectDial/DJ_EffectDial.ino
+++ b/examples/DJ/DJ_EffectDial/DJ_EffectDial.ino
@@ -78,6 +78,7 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
+		delay(1000);
 		dj.connect();
 	}
 }

--- a/examples/DJ/DJ_EffectDial/DJ_EffectDial.ino
+++ b/examples/DJ/DJ_EffectDial/DJ_EffectDial.ino
@@ -78,7 +78,7 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
-		dj.reconnect();
+		dj.connect();
 	}
 }
 

--- a/examples/Drums/Drums_DebugPrint/Drums_DebugPrint.ino
+++ b/examples/Drums/Drums_DebugPrint/Drums_DebugPrint.ino
@@ -47,6 +47,6 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
-		drums.reconnect();
+		drums.connect();
 	}
 }

--- a/examples/Drums/Drums_DebugPrint/Drums_DebugPrint.ino
+++ b/examples/Drums/Drums_DebugPrint/Drums_DebugPrint.ino
@@ -47,6 +47,7 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
+		delay(1000);
 		drums.connect();
 	}
 }

--- a/examples/Guitar/Guitar_DebugPrint/Guitar_DebugPrint.ino
+++ b/examples/Guitar/Guitar_DebugPrint/Guitar_DebugPrint.ino
@@ -47,6 +47,6 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
-		guitar.reconnect();
+		guitar.connect();
 	}
 }

--- a/examples/Guitar/Guitar_DebugPrint/Guitar_DebugPrint.ino
+++ b/examples/Guitar/Guitar_DebugPrint/Guitar_DebugPrint.ino
@@ -47,6 +47,7 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
+		delay(1000);
 		guitar.connect();
 	}
 }

--- a/examples/NES Mini/NES_DebugPrint/NES_DebugPrint.ino
+++ b/examples/NES Mini/NES_DebugPrint/NES_DebugPrint.ino
@@ -52,6 +52,6 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
-		nes.reconnect();
+		nes.connect();
 	}
 }

--- a/examples/NES Mini/NES_DebugPrint/NES_DebugPrint.ino
+++ b/examples/NES Mini/NES_DebugPrint/NES_DebugPrint.ino
@@ -52,6 +52,7 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
+		delay(1000);
 		nes.connect();
 	}
 }

--- a/examples/Nunchuk/Nunchuk_DebugPrint/Nunchuk_DebugPrint.ino
+++ b/examples/Nunchuk/Nunchuk_DebugPrint/Nunchuk_DebugPrint.ino
@@ -46,6 +46,7 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
+		delay(1000);
 		nchuk.connect();
 	}
 }

--- a/examples/Nunchuk/Nunchuk_DebugPrint/Nunchuk_DebugPrint.ino
+++ b/examples/Nunchuk/Nunchuk_DebugPrint/Nunchuk_DebugPrint.ino
@@ -46,6 +46,6 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
-		nchuk.reconnect();
+		nchuk.connect();
 	}
 }

--- a/examples/SNES Mini/SNES_DebugPrint/SNES_DebugPrint.ino
+++ b/examples/SNES Mini/SNES_DebugPrint/SNES_DebugPrint.ino
@@ -47,6 +47,7 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
+		delay(1000);
 		snes.connect();
 	}
 }

--- a/examples/SNES Mini/SNES_DebugPrint/SNES_DebugPrint.ino
+++ b/examples/SNES Mini/SNES_DebugPrint/SNES_DebugPrint.ino
@@ -47,6 +47,6 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
-		snes.reconnect();
+		snes.connect();
 	}
 }

--- a/examples/uDraw Tablet/uDraw_DebugPrint/uDraw_DebugPrint.ino
+++ b/examples/uDraw Tablet/uDraw_DebugPrint/uDraw_DebugPrint.ino
@@ -47,6 +47,6 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Tablet Disconnected!");
-		tablet.reconnect();
+		tablet.connect();
 	}
 }

--- a/examples/uDraw Tablet/uDraw_DebugPrint/uDraw_DebugPrint.ino
+++ b/examples/uDraw Tablet/uDraw_DebugPrint/uDraw_DebugPrint.ino
@@ -47,6 +47,7 @@ void loop() {
 	}
 	else {  // Data is bad :(
 		Serial.println("Tablet Disconnected!");
+		delay(1000);
 		tablet.connect();
 	}
 }

--- a/examples/uDraw Tablet/uDraw_Demo/uDraw_Demo.ino
+++ b/examples/uDraw Tablet/uDraw_Demo/uDraw_Demo.ino
@@ -46,7 +46,7 @@ void loop() {
 	if (!success) {  // Ruh roh
 		Serial.println("Controller disconnected!");
 		delay(1000);
-		tablet.reconnect();
+		tablet.connect();
 	}
 	else {
 		// Is the pen near the drawing surface?

--- a/extras/AddingControllers.md
+++ b/extras/AddingControllers.md
@@ -153,7 +153,7 @@ This includes all of the possible control data: the directional pad, +/- and hom
 ## Step #5: Add Your Controller's Identity
 Now that your controller definition is nearly done, it's time to add its identity to the list of available controllers!
 
-Open up the [`NXC_Identity.h`](../src/internal/NXC_Identity.h) file and add your controller name to the `ExtensionType` enumeration. Then, modify the `identifyController` function so that it will return your controller's ID if the identity bytes match. You can run the [`IdentifyController`](../examples/Any/IdentifyController/IdentifyController.ino) example to fetch the string of ID bytes.
+Open up the [`NXC_Identity.h`](../src/internal/NXC_Identity.h) file and add your controller name to the `ExtensionType` enumeration. Then, modify the `decodeIdentity` function so that it will return your controller's ID if the identity bytes match. You can run the [`IdentifyController`](../examples/Any/IdentifyController/IdentifyController.ino) example to fetch the string of ID bytes.
 
 Once that's done, head back to your controller's header file and add that identity value to the constructor. This will limit connections to this specific type and report problems if the type doesn't match.
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -42,6 +42,8 @@ EffectRollover	KEYWORD1
 begin	KEYWORD2
 
 connect	KEYWORD2
+specificInit	KEYWORD2
+
 update	KEYWORD2
 
 reset	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -61,6 +61,8 @@ printDebugRaw	KEYWORD2
 # I2C Comms
 initialize	KEYWORD2
 
+writeRegister	KEYWORD2
+
 requestData	KEYWORD2
 requestControlData	KEYWORD2
 requestIdentity	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -47,9 +47,11 @@ update	KEYWORD2
 reset	KEYWORD2
 
 getControllerType	KEYWORD2
-getControlData	KEYWORD2
-getRequestSize	KEYWORD2
+controllerIDMatches	KEYWORD2
 
+getControlData	KEYWORD2
+
+getRequestSize	KEYWORD2
 setRequestSize	KEYWORD2
 
 printDebug	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -58,6 +58,15 @@ printDebug	KEYWORD2
 printDebugID	KEYWORD2
 printDebugRaw	KEYWORD2
 
+# I2C Comms
+initialize	KEYWORD2
+
+requestData	KEYWORD2
+requestControlData	KEYWORD2
+requestIdentity	KEYWORD2
+
+identifyController	KEYWORD2
+
 # Helper Classes
 getChange	KEYWORD2
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -42,8 +42,6 @@ EffectRollover	KEYWORD1
 begin	KEYWORD2
 
 connect	KEYWORD2
-reconnect	KEYWORD2
-
 update	KEYWORD2
 
 reset	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -47,7 +47,7 @@ update	KEYWORD2
 reset	KEYWORD2
 
 getControllerType	KEYWORD2
-controllerIDMatches	KEYWORD2
+controllerTypeMatches	KEYWORD2
 
 getControlData	KEYWORD2
 

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -35,14 +35,20 @@ void ExtensionController::begin() {
 }
 
 boolean ExtensionController::connect() {
+	boolean success = false;  // assume no connection
+
 	disconnect();  // clear control data and id
 
 	if (initialize()) {
 		data.connectedType = identifyController();  // poll controller for its identity
-		return controllerIDMatches(); // 'connected' if the ID string matches
+		success = controllerIDMatches() && specialInit();  // 'connected' if the ID string matches and init success
 	}
 
-	return false;  // bad init
+	return success;
+}
+
+boolean ExtensionController::specialInit() {
+	return true;  // default 'success' (no special init) for generic controllers
 }
 
 void ExtensionController::disconnect() {

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -173,5 +173,5 @@ ExtensionType ExtensionController::identifyController(NXC_I2C_TYPE& i2c) {
 	if (!requestIdentity(i2c, idData)) {
 		return ExtensionType::NoController;  // Bad response from device
 	}
-	return NintendoExtensionCtrl::identifyController(idData);
+	return decodeIdentity(idData);
 }

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -35,12 +35,9 @@ void ExtensionController::begin() {
 }
 
 boolean ExtensionController::connect() {
-	disconnect();  // Clear current data
-	return reconnect();
-}
-
-boolean ExtensionController::reconnect() {
 	boolean success = false;
+
+	disconnect();  // clear current data
 
 	if (initialize()) {
 		data.connectedType = identifyController();  // poll controller for its identity

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -42,8 +42,8 @@ boolean ExtensionController::connect() {
 boolean ExtensionController::reconnect() {
 	boolean success = false;
 
-	if (initialize(data.i2c)) {
-		data.connectedType = identifyController(data.i2c);  // poll controller for its identity
+	if (initialize()) {
+		data.connectedType = identifyController();  // poll controller for its identity
 		success = update();  // Seed with initial values
 	}
 	else {
@@ -79,7 +79,7 @@ ExtensionType ExtensionController::getControllerType() const {
 }
 
 boolean ExtensionController::update() {
-	if (controllerIDMatches() && requestControlData(data.i2c, requestSize, data.controlData)) {
+	if (controllerIDMatches() && requestControlData(requestSize, data.controlData)) {
 		return verifyData(data.controlData, requestSize);
 	}
 	
@@ -118,7 +118,7 @@ void ExtensionController::printDebug(Print& output) const {
 
 void ExtensionController::printDebugID(Print& output) const {
 	uint8_t idData[ID_Size];
-	boolean success = requestIdentity(data.i2c, idData);
+	boolean success = requestIdentity(idData);
 
 	if (success) {
 		output.print("ID: ");

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -153,6 +153,10 @@ boolean ExtensionController::initialize(NXC_I2C_TYPE& i2c) {
 	return true;
 }
 
+boolean ExtensionController::writeRegister(NXC_I2C_TYPE& i2c, byte reg, byte value) {
+	return i2c_writeRegister(i2c, I2C_Addr, reg, value);
+}
+
 boolean ExtensionController::requestData(NXC_I2C_TYPE& i2c, uint8_t ptr, size_t size, uint8_t* data) {
 	return i2c_readDataArray(i2c, I2C_Addr, ptr, size, data);
 }

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -35,19 +35,14 @@ void ExtensionController::begin() {
 }
 
 boolean ExtensionController::connect() {
-	boolean success = false;
-
-	disconnect();  // clear current data
+	disconnect();  // clear control data and id
 
 	if (initialize()) {
 		data.connectedType = identifyController();  // poll controller for its identity
-		success = update();  // Seed with initial values
-	}
-	else {
-		data.connectedType = ExtensionType::NoController;  // Bad init, nothing connected
+		return controllerIDMatches(); // 'connected' if the ID string matches
 	}
 
-	return success;
+	return false;  // bad init
 }
 
 void ExtensionController::disconnect() {

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -64,7 +64,7 @@ void ExtensionController::reset() {
 }
 
 void ExtensionController::identifyController() {
-	data.connectedType = NintendoExtensionCtrl::identifyController(data.i2c);  // Polls the controller for its identity
+	data.connectedType = identifyController(data.i2c);  // Polls the controller for its identity
 }
 
 boolean ExtensionController::controllerIDMatches() const {
@@ -126,7 +126,7 @@ void ExtensionController::printDebugID(Print& output) const {
 
 	if (success) {
 		output.print("ID: ");
-		printRaw(idData, NintendoExtensionCtrl::ID_Size, HEX, output);
+		printRaw(idData, ID_Size, HEX, output);
 	}
 	else {
 		output.println("Bad ID Read");
@@ -142,4 +142,38 @@ void ExtensionController::printDebugRaw(uint8_t baseFormat, Print& output) const
 	output.print(requestSize);
 	output.print("]: ");
 	printRaw(data.controlData, requestSize, baseFormat, output);
+}
+
+
+boolean ExtensionController::initialize(NXC_I2C_TYPE& i2c) {
+	/* Initialization for unencrypted communication.
+	* *Should* work on all devices, genuine + 3rd party.
+	* See http://wiibrew.org/wiki/Wiimote/Extension_Controllers
+	*/
+	if (!i2c_writeRegister(i2c, I2C_Addr, 0xF0, 0x55)) { return false; }
+	delay(10);
+	if (!i2c_writeRegister(i2c, I2C_Addr, 0xFB, 0x00)) { return false; }
+	delay(20);
+	return true;
+}
+
+boolean ExtensionController::requestData(NXC_I2C_TYPE& i2c, uint8_t ptr, size_t size, uint8_t* data) {
+	return i2c_readDataArray(i2c, I2C_Addr, ptr, size, data);
+}
+
+boolean ExtensionController::requestControlData(NXC_I2C_TYPE& i2c, size_t size, uint8_t* controlData) {
+	return i2c_readDataArray(i2c, I2C_Addr, 0x00, size, controlData);
+}
+
+boolean ExtensionController::requestIdentity(NXC_I2C_TYPE& i2c, uint8_t* idData) {
+	return i2c_readDataArray(i2c, I2C_Addr, 0xFA, ID_Size, idData);
+}
+
+ExtensionType ExtensionController::identifyController(NXC_I2C_TYPE& i2c) {
+	uint8_t idData[ID_Size];
+
+	if (!requestIdentity(i2c, idData)) {
+		return ExtensionType::NoController;  // Bad response from device
+	}
+	return NintendoExtensionCtrl::identifyController(idData);
 }

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -41,14 +41,14 @@ boolean ExtensionController::connect() {
 
 	if (initialize()) {
 		identifyController();  // poll controller for its identity
-		success = controllerTypeMatches() && specialInit();  // 'connected' if the ID string matches and init success
+		success = controllerTypeMatches() && specificInit();  // 'connected' if the ID string matches and init success
 	}
 
 	return success;
 }
 
-boolean ExtensionController::specialInit() {
-	return true;  // default 'success' (no special init) for generic controllers
+boolean ExtensionController::specificInit() {
+	return true;  // default 'success' (no controller-specific init) for generic controllers
 }
 
 void ExtensionController::disconnect() {

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -43,7 +43,7 @@ boolean ExtensionController::reconnect() {
 	boolean success = false;
 
 	if (initialize(data.i2c)) {
-		identifyController();
+		data.connectedType = identifyController(data.i2c);  // poll controller for its identity
 		success = update();  // Seed with initial values
 	}
 	else {
@@ -61,10 +61,6 @@ void ExtensionController::disconnect() {
 void ExtensionController::reset() {
 	disconnect();
 	requestSize = MinRequestSize;  // Request size back to minimum
-}
-
-void ExtensionController::identifyController() {
-	data.connectedType = identifyController(data.i2c);  // Polls the controller for its identity
 }
 
 boolean ExtensionController::controllerIDMatches() const {

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -40,7 +40,7 @@ boolean ExtensionController::connect() {
 	disconnect();  // clear control data and id
 
 	if (initialize()) {
-		data.connectedType = identifyController();  // poll controller for its identity
+		identifyController();  // poll controller for its identity
 		success = controllerIDMatches() && specialInit();  // 'connected' if the ID string matches and init success
 	}
 

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -41,7 +41,7 @@ boolean ExtensionController::connect() {
 
 	if (initialize()) {
 		identifyController();  // poll controller for its identity
-		success = controllerIDMatches() && specialInit();  // 'connected' if the ID string matches and init success
+		success = controllerTypeMatches() && specialInit();  // 'connected' if the ID string matches and init success
 	}
 
 	return success;
@@ -61,7 +61,7 @@ void ExtensionController::reset() {
 	requestSize = MinRequestSize;  // Request size back to minimum
 }
 
-boolean ExtensionController::controllerIDMatches() const {
+boolean ExtensionController::controllerTypeMatches() const {
 	if (data.connectedType == id) {
 		return true;  // Match!
 	}
@@ -77,7 +77,7 @@ ExtensionType ExtensionController::getControllerType() const {
 }
 
 boolean ExtensionController::update() {
-	if (controllerIDMatches() && requestControlData(requestSize, data.controlData)) {
+	if (controllerTypeMatches() && requestControlData(requestSize, data.controlData)) {
 		return verifyData(data.controlData, requestSize);
 	}
 	

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -56,10 +56,12 @@ public:
 	void reset();
 
 	ExtensionType getControllerType() const;
+	boolean controllerIDMatches() const;
+
 	uint8_t getControlData(uint8_t controlIndex) const;
 	ExtensionData & getExtensionData() const;
-	size_t getRequestSize() const;
 
+	size_t getRequestSize() const;
 	void setRequestSize(size_t size = MinRequestSize);
 
 	void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
@@ -132,7 +134,6 @@ private:
 	ExtensionData &data;  // I2C and control data storage
 
 	void disconnect();
-	boolean controllerIDMatches() const;
 
 	uint8_t requestSize = MinRequestSize;
 };

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -67,11 +67,25 @@ public:
 	void printDebugRaw(Print& output = NXC_SERIAL_DEFAULT) const;
 	void printDebugRaw(uint8_t baseFormat, Print& output = NXC_SERIAL_DEFAULT) const;
 
+	const ExtensionType id = ExtensionType::AnyController;
+
+public:
 	static const uint8_t MinRequestSize = 6;   // Smallest reporting mode (0x37)
 	static const uint8_t MaxRequestSize = ExtensionData::ControlDataSize;
 
-	NXC_I2C_TYPE & i2c() const;  // Easily accessible I2C reference
-	const ExtensionType id = ExtensionType::AnyController;
+	NXC_I2C_TYPE& i2c() const;  // Easily accessible I2C reference
+
+protected:
+	static const uint8_t I2C_Addr = 0x52;  // Address for all extension controllers
+	static const uint8_t ID_Size = 6;  // Number of bytes for ID signature
+
+	static boolean initialize(NXC_I2C_TYPE& i2c);
+
+	static boolean requestData(NXC_I2C_TYPE& i2c, uint8_t ptr, size_t size, uint8_t* data);
+	static boolean requestControlData(NXC_I2C_TYPE& i2c, size_t size, uint8_t* controlData);
+	static boolean requestIdentity(NXC_I2C_TYPE& i2c, uint8_t* idData);
+
+	static ExtensionType identifyController(NXC_I2C_TYPE& i2c);
 
 protected:
 	ExtensionController(ExtensionData& dataRef, ExtensionType conID);

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -80,6 +80,8 @@ public:
 
 	static boolean initialize(NXC_I2C_TYPE& i2c);
 
+	static boolean writeRegister(NXC_I2C_TYPE& i2c, byte reg, byte value);
+
 	static boolean requestData(NXC_I2C_TYPE& i2c, uint8_t ptr, size_t size, uint8_t* data);
 	static boolean requestControlData(NXC_I2C_TYPE& i2c, size_t size, uint8_t* controlData);
 	static boolean requestIdentity(NXC_I2C_TYPE& i2c, uint8_t* idData);

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -49,7 +49,7 @@ public:
 	void begin();
 
 	boolean connect();
-	virtual boolean specialInit();
+	virtual boolean specificInit();
 
 	boolean update();
 

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -49,8 +49,6 @@ public:
 	void begin();
 
 	boolean connect();
-	boolean reconnect();
-
 	boolean update();
 
 	void reset();

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -79,14 +79,22 @@ public:
 	static const uint8_t ID_Size = 6;  // Number of bytes for ID signature
 
 	static boolean initialize(NXC_I2C_TYPE& i2c);
+	inline boolean initialize() const { return initialize(data.i2c); }
 
 	static boolean writeRegister(NXC_I2C_TYPE& i2c, byte reg, byte value);
+	inline boolean writeRegister(byte reg, byte value) const { return writeRegister(data.i2c, reg, value); }
 
 	static boolean requestData(NXC_I2C_TYPE& i2c, uint8_t ptr, size_t size, uint8_t* data);
+	inline boolean requestData(uint8_t ptr, size_t size, uint8_t* dataOut) const { return requestData(data.i2c, ptr, size, dataOut); }
+
 	static boolean requestControlData(NXC_I2C_TYPE& i2c, size_t size, uint8_t* controlData);
+	inline boolean requestControlData(size_t size, uint8_t* controlData) const { return requestControlData(data.i2c, size, controlData); }
+
 	static boolean requestIdentity(NXC_I2C_TYPE& i2c, uint8_t* idData);
+	inline boolean requestIdentity(uint8_t* idData) const { return requestIdentity(data.i2c, idData); }
 
 	static ExtensionType identifyController(NXC_I2C_TYPE& i2c);
+	inline ExtensionType identifyController() const { return identifyController(data.i2c); }
 
 protected:
 	ExtensionController(ExtensionData& dataRef, ExtensionType conID);

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -97,7 +97,7 @@ protected:
 	inline boolean requestControlData(size_t size, uint8_t* controlData) const { return requestControlData(data.i2c, size, controlData); }
 	inline boolean requestIdentity(uint8_t* idData) const { return requestIdentity(data.i2c, idData); }
 
-	inline ExtensionType identifyController() const { return identifyController(data.i2c); }
+	inline ExtensionType identifyController() const { return data.connectedType = identifyController(data.i2c); }
 
 protected:
 	ExtensionController(ExtensionData& dataRef, ExtensionType conID);

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -79,21 +79,24 @@ public:
 	static const uint8_t ID_Size = 6;  // Number of bytes for ID signature
 
 	static boolean initialize(NXC_I2C_TYPE& i2c);
-	inline boolean initialize() const { return initialize(data.i2c); }
 
 	static boolean writeRegister(NXC_I2C_TYPE& i2c, byte reg, byte value);
-	inline boolean writeRegister(byte reg, byte value) const { return writeRegister(data.i2c, reg, value); }
 
 	static boolean requestData(NXC_I2C_TYPE& i2c, uint8_t ptr, size_t size, uint8_t* data);
-	inline boolean requestData(uint8_t ptr, size_t size, uint8_t* dataOut) const { return requestData(data.i2c, ptr, size, dataOut); }
-
 	static boolean requestControlData(NXC_I2C_TYPE& i2c, size_t size, uint8_t* controlData);
-	inline boolean requestControlData(size_t size, uint8_t* controlData) const { return requestControlData(data.i2c, size, controlData); }
-
 	static boolean requestIdentity(NXC_I2C_TYPE& i2c, uint8_t* idData);
-	inline boolean requestIdentity(uint8_t* idData) const { return requestIdentity(data.i2c, idData); }
 
 	static ExtensionType identifyController(NXC_I2C_TYPE& i2c);
+
+protected:
+	inline boolean initialize() const { return initialize(data.i2c); }
+
+	inline boolean writeRegister(byte reg, byte value) const { return writeRegister(data.i2c, reg, value); }
+
+	inline boolean requestData(uint8_t ptr, size_t size, uint8_t* dataOut) const { return requestData(data.i2c, ptr, size, dataOut); }
+	inline boolean requestControlData(size_t size, uint8_t* controlData) const { return requestControlData(data.i2c, size, controlData); }
+	inline boolean requestIdentity(uint8_t* idData) const { return requestIdentity(data.i2c, idData); }
+
 	inline ExtensionType identifyController() const { return identifyController(data.i2c); }
 
 protected:

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -69,13 +69,12 @@ public:
 
 	const ExtensionType id = ExtensionType::AnyController;
 
-public:
 	static const uint8_t MinRequestSize = 6;   // Smallest reporting mode (0x37)
 	static const uint8_t MaxRequestSize = ExtensionData::ControlDataSize;
 
+public:
 	NXC_I2C_TYPE& i2c() const;  // Easily accessible I2C reference
 
-protected:
 	static const uint8_t I2C_Addr = 0x52;  // Address for all extension controllers
 	static const uint8_t ID_Size = 6;  // Number of bytes for ID signature
 

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -119,7 +119,6 @@ private:
 	ExtensionData &data;  // I2C and control data storage
 
 	void disconnect();
-	void identifyController();
 	boolean controllerIDMatches() const;
 
 	uint8_t requestSize = MinRequestSize;

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -49,6 +49,8 @@ public:
 	void begin();
 
 	boolean connect();
+	virtual boolean specialInit();
+
 	boolean update();
 
 	void reset();

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -56,7 +56,7 @@ public:
 	void reset();
 
 	ExtensionType getControllerType() const;
-	boolean controllerIDMatches() const;
+	boolean controllerTypeMatches() const;
 
 	uint8_t getControlData(uint8_t controlIndex) const;
 	ExtensionData & getExtensionData() const;

--- a/src/internal/NXC_Comms.h
+++ b/src/internal/NXC_Comms.h
@@ -40,9 +40,6 @@
 
 namespace NintendoExtensionCtrl {
 	const long I2C_ConversionDelay = 175;  // Microseconds, ~200 on AVR
-	const uint8_t I2C_Addr = 0x52;  // Address for all extension controllers
-
-	const uint8_t ID_Size = 6;
 
 	// Generic I2C slave device control functions
 	// ------------------------------------------
@@ -70,43 +67,6 @@ namespace NintendoExtensionCtrl {
 		if (!i2c_writePointer(i2c, addr, ptr)) { return false; }  // Set start for data read
 		delayMicroseconds(I2C_ConversionDelay);  // Wait for data conversion
 		return i2c_requestMultiple(i2c, addr, requestSize, dataOut);
-	}
-
-	// Extension controller specific I2C functions
-	// -------------------------------------------
-	// Control Data
-	inline boolean initialize(NXC_I2C_TYPE &i2c) {
-		/* Initialization for unencrypted communication.
-		* *Should* work on all devices, genuine + 3rd party.
-		* See http://wiibrew.org/wiki/Wiimote/Extension_Controllers
-		*/
-		if (!i2c_writeRegister(i2c, I2C_Addr, 0xF0, 0x55)) { return false; }
-		delay(10);
-		if (!i2c_writeRegister(i2c, I2C_Addr, 0xFB, 0x00)) { return false; }
-		delay(20);
-		return true;
-	}
-
-	inline boolean requestData(NXC_I2C_TYPE &i2c, uint8_t ptr, size_t size, uint8_t * data) {
-		return i2c_readDataArray(i2c, I2C_Addr, ptr, size, data);
-	}
-
-	inline boolean requestControlData(NXC_I2C_TYPE &i2c, size_t size, uint8_t * controlData) {
-		return i2c_readDataArray(i2c, I2C_Addr, 0x00, size, controlData);
-	}
-
-	// Identity
-	inline boolean requestIdentity(NXC_I2C_TYPE &i2c, uint8_t * idData) {
-		return i2c_readDataArray(i2c, I2C_Addr, 0xFA, ID_Size, idData);
-	}
-
-	inline ExtensionType identifyController(NXC_I2C_TYPE &i2c) {
-		uint8_t idData[ID_Size];
-
-		if (!requestIdentity(i2c, idData)) {
-			return ExtensionType::NoController;  // Bad response from device
-		}
-		return identifyController(idData);
 	}
 }
 

--- a/src/internal/NXC_Identity.h
+++ b/src/internal/NXC_Identity.h
@@ -38,7 +38,7 @@ enum class ExtensionType {
 };
 
 namespace NintendoExtensionCtrl {
-	inline ExtensionType identifyController(const uint8_t * idData) {
+	inline ExtensionType decodeIdentity(const uint8_t * idData) {
 		if (idData[2] == 0xA4 && idData[3] == 0x20) {  // All valid IDs
 			// Nunchuk ID: 0x0000
 			if (idData[4] == 0x00 && idData[5] == 0x00) {


### PR DESCRIPTION
This PR reworks the I²C communication setup: instead of being in the namespace, the controller-specific I²C functions are now in the `ExtensionController` class as static functions, with protected member functions that use the `data.i2c` member and have the ability to modify the `ExtensionData` when called.

This serves two purposes:
1. Better encapsulation. The `ExtensionController` class is a high level wrapper for communication and data for every controller. It makes sense to include the controller-specific I²C functions as part of that interface.

	Originally I separated these out to prevent the class from becoming too "monolithic", but as they're simple and not used anywhere else in the library I think they definitely have their home here. Note that the lower level I²C functions are still a part of the `NXC_Comms.h` header.

2. It allows derived classes (i.e. specific controllers) to write and read arbitrary data from the controller without having direct access to the I²C object.

This second point is necessary for the major feature of this PR: controller specific initialization.

The virtual function `specificInit()` has been added to the end of the `connect()` function, returning a boolean for whether the initialization is successful. Most controllers will use the original function in `ExtensionController`, but some controllers such as the Drawsome tablet (#57) require extra register writes before they'll communicate properly. Using a virtual function here lets each class specify its own extra initialization while maintaining encapsulation.

To utilize this I've made the `controllerTypeMatches` (previously `controllerIDMatches`) function public so the user can easily check if the connected controller matches the one used by the derived class, and subsequently invoke `specificInit()`. See the `MultipleTypes` example for a demonstration of how this works.

Since I'm already playing with the program's communication flow, I also decided to remove the `reconnect()` function. This was not well documented and it wasn't clear to the user how it was any different than the plain-old `connect()` function (hint: the latter did not clear the control data). Why you would want to *keep* the control data if you're trying to reconnect to a controller whose data has presumably updated in the meantime, I don't know. It seemed prudent to make the distinction at the time, but having two nearly-identical functions with no explanation as to why seems more confusing than anything else. So now the `reconnect()` function has been removed, all examples have been updated, and the `connect()` function will clear out the connected controller type and control data when called.

Aaaand since I'm now changing the examples, I added a 1 second delay during reconnect attempts, both to prevent spamming the "disconnected" notice and to wait for the user to plug the controller back in (or fix that loose breadboard wire).

Last but not least, the namespace-scoped `identifyController()` function has been refactored to `decodeIdentity()`, so as not to be confused with the class-scoped `identifyController()` function that polls the controller for its identity bytes and returns the enumerated controller type. The `extras` folder documentation has also been updated accordingly.