### PR TITLE
I2C Conversion Delay to Write Functions

### DIFF
--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -141,12 +141,12 @@ void ExtensionController::printDebugRaw(uint8_t baseFormat, Print& output) const
 
 boolean ExtensionController::initialize(NXC_I2C_TYPE& i2c) {
 	/* Initialization for unencrypted communication.
-	* *Should* work on all devices, genuine + 3rd party.
-	* See http://wiibrew.org/wiki/Wiimote/Extension_Controllers
-	*/
-	if (!i2c_writeRegister(i2c, I2C_Addr, 0xF0, 0x55)) { return false; }
+	 * This *should* work on all devices, genuine + 3rd party.
+	 * See http://wiibrew.org/wiki/Wiimote/Extension_Controllers
+	 */
+	if (!i2c_writeRegister(i2c, I2C_Addr, 0xF0, 0x55, false)) return false;
 	delay(10);
-	if (!i2c_writeRegister(i2c, I2C_Addr, 0xFB, 0x00)) { return false; }
+	if (!i2c_writeRegister(i2c, I2C_Addr, 0xFB, 0x00, false)) return false;
 	delay(20);
 	return true;
 }

--- a/src/internal/NXC_Comms.h
+++ b/src/internal/NXC_Comms.h
@@ -39,7 +39,7 @@
 #define NXC_SERIAL_DEFAULT Serial
 
 namespace NintendoExtensionCtrl {
-	const long I2C_ConversionDelay = 175;  // Microseconds, ~200 on AVR
+	const unsigned long I2C_ConversionDelay = 175;  // Microseconds, ~200 on AVR
 
 	// Generic I2C slave device control functions
 	// ------------------------------------------

--- a/src/internal/NXC_Comms.h
+++ b/src/internal/NXC_Comms.h
@@ -43,20 +43,20 @@ namespace NintendoExtensionCtrl {
 
 	// Generic I2C slave device control functions
 	// ------------------------------------------
-	inline boolean i2c_writePointer(NXC_I2C_TYPE &i2c, byte addr, byte ptr) {
+	inline boolean i2c_writePointer(NXC_I2C_TYPE &i2c, byte addr, byte ptr, boolean delay = true) {
 		i2c.beginTransmission(addr);
 		i2c.write(ptr);
 		if (i2c.endTransmission() != 0) return false;  // 0 = No Error
-		delayMicroseconds(I2C_ConversionDelay);  // Wait for data conversion
+		if(delay) delayMicroseconds(I2C_ConversionDelay);  // Wait for data conversion
 		return true;
 	}
 
-	inline boolean i2c_writeRegister(NXC_I2C_TYPE &i2c, byte addr, byte reg, byte value) {
+	inline boolean i2c_writeRegister(NXC_I2C_TYPE &i2c, byte addr, byte reg, byte value, boolean delay = true) {
 		i2c.beginTransmission(addr);
 		i2c.write(reg);
 		i2c.write(value);
 		if (i2c.endTransmission() != 0) return false;  // 0 = No Error
-		delayMicroseconds(I2C_ConversionDelay);  // Wait for data conversion
+		if (delay) delayMicroseconds(I2C_ConversionDelay);  // Wait for data conversion
 		return true;
 	}
 

--- a/src/internal/NXC_Comms.h
+++ b/src/internal/NXC_Comms.h
@@ -46,14 +46,18 @@ namespace NintendoExtensionCtrl {
 	inline boolean i2c_writePointer(NXC_I2C_TYPE &i2c, byte addr, byte ptr) {
 		i2c.beginTransmission(addr);
 		i2c.write(ptr);
-		return i2c.endTransmission() == 0;  // 0 = No Error
+		if (i2c.endTransmission() != 0) return false;  // 0 = No Error
+		delayMicroseconds(I2C_ConversionDelay);  // Wait for data conversion
+		return true;
 	}
 
 	inline boolean i2c_writeRegister(NXC_I2C_TYPE &i2c, byte addr, byte reg, byte value) {
 		i2c.beginTransmission(addr);
 		i2c.write(reg);
 		i2c.write(value);
-		return i2c.endTransmission() == 0;
+		if (i2c.endTransmission() != 0) return false;  // 0 = No Error
+		delayMicroseconds(I2C_ConversionDelay);  // Wait for data conversion
+		return true;
 	}
 
 	inline boolean i2c_requestMultiple(NXC_I2C_TYPE &i2c, byte addr, uint8_t requestSize, uint8_t * dataOut) {
@@ -64,8 +68,7 @@ namespace NintendoExtensionCtrl {
 	}
 
 	inline boolean i2c_readDataArray(NXC_I2C_TYPE &i2c, byte addr, byte ptr, uint8_t requestSize, uint8_t * dataOut) {
-		if (!i2c_writePointer(i2c, addr, ptr)) { return false; }  // Set start for data read
-		delayMicroseconds(I2C_ConversionDelay);  // Wait for data conversion
+		if (!i2c_writePointer(i2c, addr, ptr)) return false;  // Set start for data read
 		return i2c_requestMultiple(i2c, addr, requestSize, dataOut);
 	}
 }


### PR DESCRIPTION
Small pull request to move the I²C conversion delay (waiting for the controller to process the latest write command) to the I²C `write` commands instead of the `read` command. Idiomatically, this means you can call the `write` functions directly and expect the data to be correctly read by the controller without having to insert additional delays afterwards. 

Previously this worked by coincidence: the only two register writes without a read were in the initialization function, and had 10 ms and 20 ms delays after each of them, respectively. All other register writes were followed by a read (identity, control data), which meant they had the 175 us delay between the write and the read.

Now, *all* writes will insert the short delay by default, and I added a flag to the function to make the delay optional. The end result is that "new" calls to the `write` function will include this short delay, and the writes that already have delays after them (i.e. the initialization function) won't have any additional delay added. Win-win.