### PR TITLE
Classic Controller "High Resolution" Mode

### DIFF
--- a/examples/Classic Controller/Classic_DebugPrint/Classic_DebugPrint.ino
+++ b/examples/Classic Controller/Classic_DebugPrint/Classic_DebugPrint.ino
@@ -37,6 +37,8 @@ void setup() {
 		Serial.println("Classic Controller not detected!");
 		delay(1000);
 	}
+
+	//classic.setHighRes(true);  // uncomment to run in high resolution mode
 }
 
 void loop() {

--- a/examples/Classic Controller/Classic_Demo/Classic_Demo.ino
+++ b/examples/Classic Controller/Classic_Demo/Classic_Demo.ino
@@ -36,6 +36,8 @@ void setup() {
 		Serial.println("Classic Controller not detected!");
 		delay(1000);
 	}
+
+	//classic.setHighRes(true);  // uncomment to run in high resolution mode
 }
 
 void loop() {
@@ -59,7 +61,7 @@ void loop() {
 			Serial.println("released");
 		}
 
-		// Read a button (on/off, ABXY, Minus, Home, Plus, L, R, ZL, ZR)
+		// Read a button (ABXY, Minus, Home, Plus, L, R, ZL, ZR)
 		boolean aButton = classic.buttonA();
 
 		Serial.print("The A button is ");
@@ -70,13 +72,17 @@ void loop() {
 			Serial.println("released");
 		}
 
-		// Read a joystick axis (0-63 Left XY, 0-31 Right XY)
+		// Read a joystick axis (left XY, right XY)
+		//   Standard Mode: 0-63 Left, 0-31 Right
+		//   High Resolution Mode: 0-255 Left/Right
 		int joyLX = classic.leftJoyX();
 
 		Serial.print("The left joystick's X axis is at ");
 		Serial.println(joyLX);
 
-		// Read a trigger (0-31, L/R)
+		// Read a trigger (L/R)
+		//   Standard Mode: 0-31
+		//   High Resolution Mode: 0-255
 		int triggerL = classic.triggerL();
 
 		Serial.print("The left trigger is at ");

--- a/examples/Classic Controller/Classic_HighRes/Classic_HighRes.ino
+++ b/examples/Classic Controller/Classic_HighRes/Classic_HighRes.ino
@@ -1,0 +1,64 @@
+/*
+*  Project     Nintendo Extension Controller Library
+*  @author     David Madison
+*  @link       github.com/dmadison/NintendoExtensionCtrl
+*  @license    LGPLv3 - Copyright (c) 2020 David Madison
+*
+*  This file is part of the Nintendo Extension Controller Library.
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Lesser General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Lesser General Public License for more details.
+*
+*  You should have received a copy of the GNU Lesser General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*  Example:      Classic_HighRes
+*  Description:  Connect to a Classic Controller and demonstrate the "high res"
+*                mode by switching back and forth between the standard and
+*                high resolution maps.
+*/
+
+#include <NintendoExtensionCtrl.h>
+
+const unsigned long SwitchTime = 6000;  // ms, time to switch between low and high res modes (6 seconds)
+unsigned long lastSwitch = 0;  // timestamp, when the last switch was made
+
+ClassicController classic;
+
+void setup() {
+	Serial.begin(115200);
+	classic.begin();
+
+	while (!classic.connect()) {
+		Serial.println("Classic Controller not detected!");
+		delay(1000);
+	}
+	classic.setHighRes(true);  // let's start in high res mode
+}
+
+void loop() {
+	boolean success = classic.update();  // Get new data from the controller
+
+	if (success == true) {  // We've got data!
+		classic.printDebug();  // Print all of the values!
+
+		if (millis() - lastSwitch >= SwitchTime) {  // wait until it's time to switch
+			lastSwitch = millis();  // save the timestamp
+			boolean hr = classic.getHighRes();  // are we in high res or not?
+			hr = !hr;  // flip it, let's go to the other one
+			classic.setHighRes(hr);  // set the new mode
+		}
+	}
+	else {  // Data is bad :(
+		Serial.println("Controller Disconnected!");
+		delay(1000);
+		classic.connect();
+	}
+}

--- a/examples/NES Mini/NES_DebugPrint/NES_DebugPrint.ino
+++ b/examples/NES Mini/NES_DebugPrint/NES_DebugPrint.ino
@@ -37,26 +37,17 @@ void setup() {
 		Serial.println("Classic Controller not detected!");
 		delay(1000);
 	}
-
-	if (nes.update() && nes.isThirdParty()) {  // Uh oh, looks like your controller isn't genuine?
-		nes.setRequestSize(8);  // Requires 8 or more bytes for third party controllers
-	}
 }
 
 void loop() {
 	boolean success = nes.update();  // Get new data from the controller
 
 	if (success == true) {  // We've got data!
-		nes.fixThirdPartyData();  // If third party controller, fix the data!
 		nes.printDebug();  // Print all of the values!
 	}
 	else {  // Data is bad :(
 		Serial.println("Controller Disconnected!");
 		delay(1000);
 		nes.connect();
-
-		if (nes.update() && nes.isThirdParty()) {  // Uh oh, looks like your controller isn't genuine?
-			nes.setRequestSize(8);  // Requires 8 or more bytes for third party controllers
-		}
 	}
 }

--- a/examples/NES Mini/NES_Demo/NES_Demo.ino
+++ b/examples/NES Mini/NES_Demo/NES_Demo.ino
@@ -36,10 +36,6 @@ void setup() {
 		Serial.println("NES Classic Controller not detected!");
 		delay(1000);
 	}
-
-	if (nes.update() && nes.isThirdParty()) {  // Uh oh, looks like your controller isn't genuine?
-		nes.setRequestSize(8);  // Requires 8 or more bytes for third party controllers
-	}
 }
 
 void loop() {
@@ -52,9 +48,6 @@ void loop() {
 		delay(1000);
 	}
 	else {
-		// If a third party controller is detected, fix the data!
-		nes.fixThirdPartyData();
-
 		// Read the DPAD (Up/Down/Left/Right)
 		boolean padUp = nes.dpadUp();
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -90,6 +90,9 @@ rollAngle	KEYWORD2
 pitchAngle	KEYWORD2
 
 ## Classic Controller
+setHighRes	KEYWORD2
+getHighRes	KEYWORD2
+
 leftJoyX	KEYWORD2
 leftJoyY	KEYWORD2
 
@@ -202,10 +205,6 @@ getNumTurntables	KEYWORD2
 
 ## NES Mini Controller
 # (Covered by the Classic Controller keywords)
-isNESThirdParty	KEYWORD2
-fixNESThirdPartyData	KEYWORD2
-isThirdParty	KEYWORD2
-fixThirdPartyData	KEYWORD2
 
 ## SNES Mini Controller
 # (Covered by the Classic Controller keywords)

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -24,6 +24,7 @@
 
 namespace NintendoExtensionCtrl {
 
+// Standard Maps
 constexpr ByteMap ClassicController_Shared::Maps::LeftJoyX;
 constexpr ByteMap ClassicController_Shared::Maps::LeftJoyY;
 
@@ -52,76 +53,138 @@ constexpr BitMap  ClassicController_Shared::Maps::ButtonPlus;
 constexpr BitMap  ClassicController_Shared::Maps::ButtonMinus;
 constexpr BitMap  ClassicController_Shared::Maps::ButtonHome;
 
+
+// High Resolution Maps
+constexpr IndexMap ClassicController_Shared::MapsHR::LeftJoyX;
+constexpr IndexMap ClassicController_Shared::MapsHR::LeftJoyY;
+
+constexpr IndexMap ClassicController_Shared::MapsHR::RightJoyX;
+constexpr IndexMap ClassicController_Shared::MapsHR::RightJoyY;
+
+constexpr BitMap   ClassicController_Shared::MapsHR::DpadUp;
+constexpr BitMap   ClassicController_Shared::MapsHR::DpadDown;
+constexpr BitMap   ClassicController_Shared::MapsHR::DpadLeft;
+constexpr BitMap   ClassicController_Shared::MapsHR::DpadRight;
+
+constexpr BitMap   ClassicController_Shared::MapsHR::ButtonA;
+constexpr BitMap   ClassicController_Shared::MapsHR::ButtonB;
+constexpr BitMap   ClassicController_Shared::MapsHR::ButtonX;
+constexpr BitMap   ClassicController_Shared::MapsHR::ButtonY;
+
+constexpr IndexMap ClassicController_Shared::MapsHR::TriggerL;
+constexpr IndexMap ClassicController_Shared::MapsHR::TriggerR;
+
+constexpr BitMap   ClassicController_Shared::MapsHR::ButtonL;
+constexpr BitMap   ClassicController_Shared::MapsHR::ButtonR;
+constexpr BitMap   ClassicController_Shared::MapsHR::ButtonZL;
+constexpr BitMap   ClassicController_Shared::MapsHR::ButtonZR;
+
+constexpr BitMap   ClassicController_Shared::MapsHR::ButtonPlus;
+constexpr BitMap   ClassicController_Shared::MapsHR::ButtonMinus;
+constexpr BitMap   ClassicController_Shared::MapsHR::ButtonHome;
+
+
+/* Making use of the preprocessor here to repeat these conditionals for every
+ * data retrieving function in the class. I'd rather trust the preprocessor
+ * here than pass the constexpr objects through a nested function and hope
+ * the compiler properly optimizes it. Plus I don't have to trust myself
+ * to copy the mapping name twice.
+ *
+ * If the controller is not in "high resolution" mode (according to the class
+ * data), return the controlData or controlBit function for the specified map
+ * in the "standard" maps (Maps::). If the controller *is* in "high resolution"
+ * mode, return the controlData or controlBit function for the specified map
+ * of the same name in the "high resolution" maps (MapsHR::).
+ */
+#define HRDATA(map) !highRes ? getControlData(Maps::map) : getControlData(MapsHR::map)
+#define HRBIT(map)  !highRes ? getControlBit(Maps::map) : getControlBit(MapsHR::map)
+
+
+boolean ClassicController_Shared::setHighRes(boolean hr) {
+	const uint8_t regVal = hr ? 0x03 : 0x01;  // 0x03 for high res, 0x01 for standard
+	boolean success = writeRegister(0xFE, regVal);  // write to controller
+	if (success == true) {
+		highRes = hr;  // save 'high res' setting
+		if (highRes == true && getRequestSize() < 8) setRequestSize(8);  // 8 bytes needed for hr mode
+		else if (highRes == false) setRequestSize(MinRequestSize);  // if not in HR, set back to min
+	}
+	return success;
+}
+
+boolean ClassicController_Shared::getHighRes() const {
+	return highRes;
+}
+
 uint8_t ClassicController_Shared::leftJoyX() const {
-	return getControlData(Maps::LeftJoyX);
+	return HRDATA(LeftJoyX);
 }
 
 uint8_t ClassicController_Shared::leftJoyY() const {
-	return getControlData(Maps::LeftJoyY);
+	return HRDATA(LeftJoyY);
 }
 
 uint8_t ClassicController_Shared::rightJoyX() const {
-	return getControlData(Maps::RightJoyX);
+	return HRDATA(RightJoyX);
 }
 
 uint8_t ClassicController_Shared::rightJoyY() const {
-	return getControlData(Maps::RightJoyY);
+	return HRDATA(RightJoyY);
 }
 
 boolean ClassicController_Shared::dpadUp() const {
-	return getControlBit(Maps::DpadUp);
+	return HRBIT(DpadUp);
 }
 
 boolean ClassicController_Shared::dpadDown() const {
-	return getControlBit(Maps::DpadDown);
+	return HRBIT(DpadDown);
 }
 
 boolean ClassicController_Shared::dpadLeft() const {
-	return getControlBit(Maps::DpadLeft);
+	return HRBIT(DpadLeft);
 }
 
 boolean ClassicController_Shared::dpadRight() const {
-	return getControlBit(Maps::DpadRight);
+	return HRBIT(DpadRight);
 }
 
 boolean ClassicController_Shared::buttonA() const {
-	return getControlBit(Maps::ButtonA);
+	return HRBIT(ButtonA);
 }
 
 boolean ClassicController_Shared::buttonB() const {
-	return getControlBit(Maps::ButtonB);
+	return HRBIT(ButtonB);
 }
 
 boolean ClassicController_Shared::buttonX() const {
-	return getControlBit(Maps::ButtonX);
+	return HRBIT(ButtonX);
 }
 
 boolean ClassicController_Shared::buttonY() const {
-	return getControlBit(Maps::ButtonY);
+	return HRBIT(ButtonY);
 }
 
 uint8_t ClassicController_Shared::triggerL() const {
-	return getControlData(Maps::TriggerL);
+	return HRDATA(TriggerL);
 }
 
 uint8_t ClassicController_Shared::triggerR() const {
-	return getControlData(Maps::TriggerR);
+	return HRDATA(TriggerR);
 }
 
 boolean ClassicController_Shared::buttonL() const {
-	return getControlBit(Maps::ButtonL);
+	return HRBIT(ButtonL);
 }
 
 boolean ClassicController_Shared::buttonR() const {
-	return getControlBit(Maps::ButtonR);
+	return HRBIT(ButtonR);
 }
 
 boolean ClassicController_Shared::buttonZL() const {
-	return getControlBit(Maps::ButtonZL);
+	return HRBIT(ButtonZL);
 }
 
 boolean ClassicController_Shared::buttonZR() const {
-	return getControlBit(Maps::ButtonZR);
+	return HRBIT(ButtonZR);
 }
 
 boolean ClassicController_Shared::buttonStart() const {
@@ -133,21 +196,21 @@ boolean ClassicController_Shared::buttonSelect() const {
 }
 
 boolean ClassicController_Shared::buttonPlus() const {
-	return getControlBit(Maps::ButtonPlus);
+	return HRBIT(ButtonPlus);
 }
 
 boolean ClassicController_Shared::buttonMinus() const {
-	return getControlBit(Maps::ButtonMinus);
+	return HRBIT(ButtonMinus);
 }
 
 boolean ClassicController_Shared::buttonHome() const {
-	return getControlBit(Maps::ButtonHome);
+	return HRBIT(ButtonHome);
 }
 
 void ClassicController_Shared::printDebug(Print& output) const {
 	const char fillCharacter = '_';
 
-	char buffer[62];
+	char buffer[68];
 
 	char dpadLPrint = dpadLeft() ? '<' : fillCharacter;
 	char dpadUPrint = dpadUp() ? '^' : fillCharacter;
@@ -170,15 +233,20 @@ void ClassicController_Shared::printDebug(Print& output) const {
 	char zrButtonPrint = buttonZR() ? 'R' : fillCharacter;
 
 	output.print("Classic ");
+
 	sprintf(buffer,
-		"%c%c%c%c | %c%c%c | %c%c%c%c L:(%2u, %2u) R:(%2u, %2u) | LT:%2u%c RT:%2u%c Z:%c%c",
+		"%c%c%c%c | %c%c%c | %c%c%c%c L:(%3u, %3u) R:(%3u, %3u) | LT:%3u%c RT:%3u%c Z:%c%c",
 		dpadLPrint, dpadUPrint, dpadDPrint, dpadRPrint,
 		minusPrint, homePrint, plusPrint,
 		aButtonPrint, bButtonPrint, xButtonPrint, yButtonPrint,
 		leftJoyX(), leftJoyY(), rightJoyX(), rightJoyY(),
 		triggerL(), ltButtonPrint, triggerR(), rtButtonPrint,
 		zlButtonPrint, zrButtonPrint);
-	output.println(buffer);
+	
+	output.print(buffer);
+	if (getHighRes()) output.print(" (High Res)");
+
+	output.println();
 }
 
 // ######### Mini Controller Support #########

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -249,97 +249,14 @@ void ClassicController_Shared::printDebug(Print& output) const {
 	output.println();
 }
 
+
 // ######### Mini Controller Support #########
 
-boolean ClassicController_Shared::fixNESThirdPartyData(boolean force) {
-	// Public-facing function to check and "correct" data if using a third party controller
-	// Returns 'true' if data was modified
-	if((isNESThirdParty() && getRequestSize() >= 8) || force == true) {  // 8 bytes is the minimum for valid data
-		manipulateThirdPartyData();
-		return true;
-	}
-	return false;
-}
-
-boolean ClassicController_Shared::isNESThirdParty() const {
-	// The third party NES controllers I've come across seem to display the same
-	// unchanging pattern for the first six control bytes:
-	//
-	//     0x81, 0x81, 0x81, 0x81, 0x00, 0x00
-	//
-	// This is mostly garbage data that doesn't line up with the Classic Controller
-	// at all. Using the library's debug output, here is what it translates to:
-	//
-	//    <^v> | -H+ | ABXY L:( 1,  1) R:(21,  1) | LT: 4X RT: 1X Z:LR
-	//
-	// You'll notice a few things. ALL possible buttons are pressed. The left analog 
-	// stick is completely down and to the left, while the right analog stick is down
-	// and to the right. On the back, both trigger "fully depressed" buttons are
-	// down, and yet the analog trigger values are very low. In short, this is a
-	// difficult if not impossible state for a normal Classic Controller to be in.
-	// Because of that, we can reasonably assume that if the bytes match this then the
-	// connected controller is a third party NES controller, and can be treated accordingly. 
-	//
-	// -------
-	//
-	// Issue #46 states that the 8BitDo Retro Receiver, another 3rd party controller,
-	// has a different set of data for the first six bytes:
-	//
-	//    0x84, 0x86, 0x86, 0x86, 0x00, 0x00
-	//
-	// Which, again using the library's debug output, evaluates to:
-	//
-	//    <^v> | -H+ | ABXY L:( 4,  6) R:(21,  6) | LT: 4X RT: 6X Z:LR
-	//
-	// This has been added in as a second conditional check.
-	//
-	// If any other 3rd party NES controllers have a different signature than these two,
-	// I'm going to modify this signature check to only check the last two bytes (4 & 5) as 0.
-
-	       // 3rd Party Data Signature, Typical
-	return (getControlData(0) == 0x81 &&  // RX 4:3, LX
-	        getControlData(1) == 0x81 &&  // RX 2:1, LY
-	        getControlData(2) == 0x81 &&  // RX 0, LT 4:3, RY
-	        getControlData(3) == 0x81 &&  // LT 2:0, RT
-	        getControlData(4) == 0x00 &&  // Button packet 1 (all pressed)
-	        getControlData(5) == 0x00)    // Button packet 2 (all pressed)
-	||
-	       // 8BitDo Retro Receiver Signature
-	       (getControlData(0) == 0x84 &&  // RX 4:3, LX
-	        getControlData(1) == 0x86 &&  // RX 2:1, LY
-	        getControlData(2) == 0x86 &&  // RX 0, LT 4:3, RY
-	        getControlData(3) == 0x86 &&  // LT 2:0, RT
-	        getControlData(4) == 0x00 &&  // Button packet 1 (all pressed)
-	        getControlData(5) == 0x00);   // Button packet 2 (all pressed)
-}
-
-void ClassicController_Shared::manipulateThirdPartyData() {
-	// The data returned by third party NES controllers for the missing control surfaces
-	// (joysticks, triggers, etc.) is "corrupted", meaning that it doesn't align with
-	// what you would expect a Classic Controller at rest to display.
-	//
-	// A friend of mine kindly tested his genuine NES controller, and here are the first
-	// six bytes it reports by default:
-	//
-	//     0x5F 0xDF 0x8F 0x00 0xFF 0xFF
-	//
-	// Using the library's debug output, here is what it translates to:
-	//
-	//      ____ | ___ | ____ L : (31, 31) R : (15, 15) | LT : 0_ RT : 0_ Z : __
-	//
-	// The left joystick is centered at 31/31, the right joystick is centered at 15/15,
-	// the analog trigger values are 0, and all buttons are released.
-	//
-	// For the third party NES Mini controllers, only the two data packets containing the button
-	// booleans matter. Bytes 0, 1, 2, and 3 (joysticks and triggers) are replaced entirely.
-	// Bytes 4 and 5 are overridden by the values in 6 and 7.
-
-	setControlData(0, 0x5F);
-	setControlData(1, 0xDF);
-	setControlData(2, 0x8F);
-	setControlData(3, 0x00);
-	setControlData(4, getControlData(6));
-	setControlData(5, getControlData(7));
+boolean MiniControllerBase::specificInit() {
+	// all mini controllers use high res format, and some of the cheaper third
+	// party ones will not work without it. So we're going to set this on
+	// connection for all of them
+	return setHighRes(true);
 }
 
 void NESMiniController_Shared::printDebug(Print& output) const {

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -24,6 +24,7 @@
 
 namespace NintendoExtensionCtrl {
 
+// Classic Controller, Standard Data Map Storage
 constexpr ByteMap ClassicDataMap_Std::LeftJoyX;
 constexpr ByteMap ClassicDataMap_Std::LeftJoyY;
 
@@ -51,6 +52,37 @@ constexpr BitMap  ClassicDataMap_Std::ButtonZR;
 constexpr BitMap  ClassicDataMap_Std::ButtonPlus;
 constexpr BitMap  ClassicDataMap_Std::ButtonMinus;
 constexpr BitMap  ClassicDataMap_Std::ButtonHome;
+
+
+// Classic Controller, "High Resolution" Data Map Storage
+constexpr IndexMap ClassicDataMap_HighRes::LeftJoyX;
+constexpr IndexMap ClassicDataMap_HighRes::LeftJoyY;
+
+constexpr IndexMap ClassicDataMap_HighRes::RightJoyX;
+constexpr IndexMap ClassicDataMap_HighRes::RightJoyY;
+
+constexpr BitMap   ClassicDataMap_HighRes::DpadUp;
+constexpr BitMap   ClassicDataMap_HighRes::DpadDown;
+constexpr BitMap   ClassicDataMap_HighRes::DpadLeft;
+constexpr BitMap   ClassicDataMap_HighRes::DpadRight;
+
+constexpr BitMap   ClassicDataMap_HighRes::ButtonA;
+constexpr BitMap   ClassicDataMap_HighRes::ButtonB;
+constexpr BitMap   ClassicDataMap_HighRes::ButtonX;
+constexpr BitMap   ClassicDataMap_HighRes::ButtonY;
+
+constexpr IndexMap ClassicDataMap_HighRes::TriggerL;
+constexpr IndexMap ClassicDataMap_HighRes::TriggerR;
+
+constexpr BitMap   ClassicDataMap_HighRes::ButtonL;
+constexpr BitMap   ClassicDataMap_HighRes::ButtonR;
+constexpr BitMap   ClassicDataMap_HighRes::ButtonZL;
+constexpr BitMap   ClassicDataMap_HighRes::ButtonZR;
+
+constexpr BitMap   ClassicDataMap_HighRes::ButtonPlus;
+constexpr BitMap   ClassicDataMap_HighRes::ButtonMinus;
+constexpr BitMap   ClassicDataMap_HighRes::ButtonHome;
+
 
 template<class DataMaps>
 uint8_t ClassicControllerCore<DataMaps>::leftJoyX() const {
@@ -208,6 +240,12 @@ void ClassicControllerCore<DataMaps>::printDebug(Print& output) const {
 
 // ######### Mini Controller Support #########
 
+boolean ClassicControllerHR_Shared::specificInit() {
+	boolean success = writeRegister(0xFE, 0x03);  // set "high res" mode
+	if (success && getRequestSize() < 8) setRequestSize(8);  // 8 or more bytes of control data needed for this mode
+	return success;
+}
+
 template<class DataMaps>
 boolean ClassicControllerCore<DataMaps>::fixNESThirdPartyData(boolean force) {
 	// Public-facing function to check and "correct" data if using a third party controller
@@ -355,5 +393,6 @@ void SNESMiniController_Shared::printDebug(Print& output) const {
 }
 
 template class ClassicControllerCore<ClassicDataMap_Std>;  // Standard Mappings
+template class ClassicControllerCore<ClassicDataMap_HighRes>;  // "High Resolution" Mappings
 
 }  // End "NintendoExtensionCtrl" namespace

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -24,33 +24,33 @@
 
 namespace NintendoExtensionCtrl {
 
-constexpr ByteMap ClassicController_Shared::Maps::LeftJoyX;
-constexpr ByteMap ClassicController_Shared::Maps::LeftJoyY;
+constexpr ByteMap ClassicDataMap_Std::LeftJoyX;
+constexpr ByteMap ClassicDataMap_Std::LeftJoyY;
 
-constexpr ByteMap ClassicController_Shared::Maps::RightJoyX[3];
-constexpr ByteMap ClassicController_Shared::Maps::RightJoyY;
+constexpr ByteMap ClassicDataMap_Std::RightJoyX[3];
+constexpr ByteMap ClassicDataMap_Std::RightJoyY;
 
-constexpr BitMap  ClassicController_Shared::Maps::DpadUp;
-constexpr BitMap  ClassicController_Shared::Maps::DpadDown;
-constexpr BitMap  ClassicController_Shared::Maps::DpadLeft;
-constexpr BitMap  ClassicController_Shared::Maps::DpadRight;
+constexpr BitMap  ClassicDataMap_Std::DpadUp;
+constexpr BitMap  ClassicDataMap_Std::DpadDown;
+constexpr BitMap  ClassicDataMap_Std::DpadLeft;
+constexpr BitMap  ClassicDataMap_Std::DpadRight;
 
-constexpr BitMap  ClassicController_Shared::Maps::ButtonA;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonB;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonX;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonY;
+constexpr BitMap  ClassicDataMap_Std::ButtonA;
+constexpr BitMap  ClassicDataMap_Std::ButtonB;
+constexpr BitMap  ClassicDataMap_Std::ButtonX;
+constexpr BitMap  ClassicDataMap_Std::ButtonY;
 
-constexpr ByteMap ClassicController_Shared::Maps::TriggerL[2];
-constexpr ByteMap ClassicController_Shared::Maps::TriggerR;
+constexpr ByteMap ClassicDataMap_Std::TriggerL[2];
+constexpr ByteMap ClassicDataMap_Std::TriggerR;
 
-constexpr BitMap  ClassicController_Shared::Maps::ButtonL;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonR;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonZL;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonZR;
+constexpr BitMap  ClassicDataMap_Std::ButtonL;
+constexpr BitMap  ClassicDataMap_Std::ButtonR;
+constexpr BitMap  ClassicDataMap_Std::ButtonZL;
+constexpr BitMap  ClassicDataMap_Std::ButtonZR;
 
-constexpr BitMap  ClassicController_Shared::Maps::ButtonPlus;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonMinus;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonHome;
+constexpr BitMap  ClassicDataMap_Std::ButtonPlus;
+constexpr BitMap  ClassicDataMap_Std::ButtonMinus;
+constexpr BitMap  ClassicDataMap_Std::ButtonHome;
 
 uint8_t ClassicController_Shared::leftJoyX() const {
 	return getControlData(Maps::LeftJoyX);

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -52,99 +52,123 @@ constexpr BitMap  ClassicDataMap_Std::ButtonPlus;
 constexpr BitMap  ClassicDataMap_Std::ButtonMinus;
 constexpr BitMap  ClassicDataMap_Std::ButtonHome;
 
-uint8_t ClassicController_Shared::leftJoyX() const {
+template<class DataMaps>
+uint8_t ClassicControllerCore<DataMaps>::leftJoyX() const {
 	return getControlData(Maps::LeftJoyX);
 }
 
-uint8_t ClassicController_Shared::leftJoyY() const {
+template<class DataMaps>
+uint8_t ClassicControllerCore<DataMaps>::leftJoyY() const {
 	return getControlData(Maps::LeftJoyY);
 }
 
-uint8_t ClassicController_Shared::rightJoyX() const {
+template<class DataMaps>
+uint8_t ClassicControllerCore<DataMaps>::rightJoyX() const {
 	return getControlData(Maps::RightJoyX);
 }
 
-uint8_t ClassicController_Shared::rightJoyY() const {
+template<class DataMaps>
+uint8_t ClassicControllerCore<DataMaps>::rightJoyY() const {
 	return getControlData(Maps::RightJoyY);
 }
 
-boolean ClassicController_Shared::dpadUp() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::dpadUp() const {
 	return getControlBit(Maps::DpadUp);
 }
 
-boolean ClassicController_Shared::dpadDown() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::dpadDown() const {
 	return getControlBit(Maps::DpadDown);
 }
 
-boolean ClassicController_Shared::dpadLeft() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::dpadLeft() const {
 	return getControlBit(Maps::DpadLeft);
 }
 
-boolean ClassicController_Shared::dpadRight() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::dpadRight() const {
 	return getControlBit(Maps::DpadRight);
 }
 
-boolean ClassicController_Shared::buttonA() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::buttonA() const {
 	return getControlBit(Maps::ButtonA);
 }
 
-boolean ClassicController_Shared::buttonB() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::buttonB() const {
 	return getControlBit(Maps::ButtonB);
 }
 
-boolean ClassicController_Shared::buttonX() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::buttonX() const {
 	return getControlBit(Maps::ButtonX);
 }
 
-boolean ClassicController_Shared::buttonY() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::buttonY() const {
 	return getControlBit(Maps::ButtonY);
 }
 
-uint8_t ClassicController_Shared::triggerL() const {
+template<class DataMaps>
+uint8_t ClassicControllerCore<DataMaps>::triggerL() const {
 	return getControlData(Maps::TriggerL);
 }
 
-uint8_t ClassicController_Shared::triggerR() const {
+template<class DataMaps>
+uint8_t ClassicControllerCore<DataMaps>::triggerR() const {
 	return getControlData(Maps::TriggerR);
 }
 
-boolean ClassicController_Shared::buttonL() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::buttonL() const {
 	return getControlBit(Maps::ButtonL);
 }
 
-boolean ClassicController_Shared::buttonR() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::buttonR() const {
 	return getControlBit(Maps::ButtonR);
 }
 
-boolean ClassicController_Shared::buttonZL() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::buttonZL() const {
 	return getControlBit(Maps::ButtonZL);
 }
 
-boolean ClassicController_Shared::buttonZR() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::buttonZR() const {
 	return getControlBit(Maps::ButtonZR);
 }
 
-boolean ClassicController_Shared::buttonStart() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::buttonStart() const {
 	return buttonPlus();
 }
 
-boolean ClassicController_Shared::buttonSelect() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::buttonSelect() const {
 	return buttonMinus();
 }
 
-boolean ClassicController_Shared::buttonPlus() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::buttonPlus() const {
 	return getControlBit(Maps::ButtonPlus);
 }
 
-boolean ClassicController_Shared::buttonMinus() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::buttonMinus() const {
 	return getControlBit(Maps::ButtonMinus);
 }
 
-boolean ClassicController_Shared::buttonHome() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::buttonHome() const {
 	return getControlBit(Maps::ButtonHome);
 }
 
-void ClassicController_Shared::printDebug(Print& output) const {
+template<class DataMaps>
+void ClassicControllerCore<DataMaps>::printDebug(Print& output) const {
 	const char fillCharacter = '_';
 
 	char buffer[62];
@@ -181,9 +205,11 @@ void ClassicController_Shared::printDebug(Print& output) const {
 	output.println(buffer);
 }
 
+
 // ######### Mini Controller Support #########
 
-boolean ClassicController_Shared::fixNESThirdPartyData(boolean force) {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::fixNESThirdPartyData(boolean force) {
 	// Public-facing function to check and "correct" data if using a third party controller
 	// Returns 'true' if data was modified
 	if((isNESThirdParty() && getRequestSize() >= 8) || force == true) {  // 8 bytes is the minimum for valid data
@@ -193,7 +219,8 @@ boolean ClassicController_Shared::fixNESThirdPartyData(boolean force) {
 	return false;
 }
 
-boolean ClassicController_Shared::isNESThirdParty() const {
+template<class DataMaps>
+boolean ClassicControllerCore<DataMaps>::isNESThirdParty() const {
 	// The third party NES controllers I've come across seem to display the same
 	// unchanging pattern for the first six control bytes:
 	//
@@ -245,7 +272,8 @@ boolean ClassicController_Shared::isNESThirdParty() const {
 	        getControlData(5) == 0x00);   // Button packet 2 (all pressed)
 }
 
-void ClassicController_Shared::manipulateThirdPartyData() {
+template<class DataMaps>
+void ClassicControllerCore<DataMaps>::manipulateThirdPartyData() {
 	// The data returned by third party NES controllers for the missing control surfaces
 	// (joysticks, triggers, etc.) is "corrupted", meaning that it doesn't align with
 	// what you would expect a Classic Controller at rest to display.
@@ -325,5 +353,7 @@ void SNESMiniController_Shared::printDebug(Print& output) const {
 
 	output.println();
 }
+
+template class ClassicControllerCore<ClassicDataMap_Std>;  // Standard Mappings
 
 }  // End "NintendoExtensionCtrl" namespace

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -24,183 +24,127 @@
 
 namespace NintendoExtensionCtrl {
 
-// Classic Controller, Standard Data Map Storage
-constexpr ByteMap ClassicDataMap_Std::LeftJoyX;
-constexpr ByteMap ClassicDataMap_Std::LeftJoyY;
+constexpr ByteMap ClassicController_Shared::Maps::LeftJoyX;
+constexpr ByteMap ClassicController_Shared::Maps::LeftJoyY;
 
-constexpr ByteMap ClassicDataMap_Std::RightJoyX[3];
-constexpr ByteMap ClassicDataMap_Std::RightJoyY;
+constexpr ByteMap ClassicController_Shared::Maps::RightJoyX[3];
+constexpr ByteMap ClassicController_Shared::Maps::RightJoyY;
 
-constexpr BitMap  ClassicDataMap_Std::DpadUp;
-constexpr BitMap  ClassicDataMap_Std::DpadDown;
-constexpr BitMap  ClassicDataMap_Std::DpadLeft;
-constexpr BitMap  ClassicDataMap_Std::DpadRight;
+constexpr BitMap  ClassicController_Shared::Maps::DpadUp;
+constexpr BitMap  ClassicController_Shared::Maps::DpadDown;
+constexpr BitMap  ClassicController_Shared::Maps::DpadLeft;
+constexpr BitMap  ClassicController_Shared::Maps::DpadRight;
 
-constexpr BitMap  ClassicDataMap_Std::ButtonA;
-constexpr BitMap  ClassicDataMap_Std::ButtonB;
-constexpr BitMap  ClassicDataMap_Std::ButtonX;
-constexpr BitMap  ClassicDataMap_Std::ButtonY;
+constexpr BitMap  ClassicController_Shared::Maps::ButtonA;
+constexpr BitMap  ClassicController_Shared::Maps::ButtonB;
+constexpr BitMap  ClassicController_Shared::Maps::ButtonX;
+constexpr BitMap  ClassicController_Shared::Maps::ButtonY;
 
-constexpr ByteMap ClassicDataMap_Std::TriggerL[2];
-constexpr ByteMap ClassicDataMap_Std::TriggerR;
+constexpr ByteMap ClassicController_Shared::Maps::TriggerL[2];
+constexpr ByteMap ClassicController_Shared::Maps::TriggerR;
 
-constexpr BitMap  ClassicDataMap_Std::ButtonL;
-constexpr BitMap  ClassicDataMap_Std::ButtonR;
-constexpr BitMap  ClassicDataMap_Std::ButtonZL;
-constexpr BitMap  ClassicDataMap_Std::ButtonZR;
+constexpr BitMap  ClassicController_Shared::Maps::ButtonL;
+constexpr BitMap  ClassicController_Shared::Maps::ButtonR;
+constexpr BitMap  ClassicController_Shared::Maps::ButtonZL;
+constexpr BitMap  ClassicController_Shared::Maps::ButtonZR;
 
-constexpr BitMap  ClassicDataMap_Std::ButtonPlus;
-constexpr BitMap  ClassicDataMap_Std::ButtonMinus;
-constexpr BitMap  ClassicDataMap_Std::ButtonHome;
+constexpr BitMap  ClassicController_Shared::Maps::ButtonPlus;
+constexpr BitMap  ClassicController_Shared::Maps::ButtonMinus;
+constexpr BitMap  ClassicController_Shared::Maps::ButtonHome;
 
-
-// Classic Controller, "High Resolution" Data Map Storage
-constexpr IndexMap ClassicDataMap_HighRes::LeftJoyX;
-constexpr IndexMap ClassicDataMap_HighRes::LeftJoyY;
-
-constexpr IndexMap ClassicDataMap_HighRes::RightJoyX;
-constexpr IndexMap ClassicDataMap_HighRes::RightJoyY;
-
-constexpr BitMap   ClassicDataMap_HighRes::DpadUp;
-constexpr BitMap   ClassicDataMap_HighRes::DpadDown;
-constexpr BitMap   ClassicDataMap_HighRes::DpadLeft;
-constexpr BitMap   ClassicDataMap_HighRes::DpadRight;
-
-constexpr BitMap   ClassicDataMap_HighRes::ButtonA;
-constexpr BitMap   ClassicDataMap_HighRes::ButtonB;
-constexpr BitMap   ClassicDataMap_HighRes::ButtonX;
-constexpr BitMap   ClassicDataMap_HighRes::ButtonY;
-
-constexpr IndexMap ClassicDataMap_HighRes::TriggerL;
-constexpr IndexMap ClassicDataMap_HighRes::TriggerR;
-
-constexpr BitMap   ClassicDataMap_HighRes::ButtonL;
-constexpr BitMap   ClassicDataMap_HighRes::ButtonR;
-constexpr BitMap   ClassicDataMap_HighRes::ButtonZL;
-constexpr BitMap   ClassicDataMap_HighRes::ButtonZR;
-
-constexpr BitMap   ClassicDataMap_HighRes::ButtonPlus;
-constexpr BitMap   ClassicDataMap_HighRes::ButtonMinus;
-constexpr BitMap   ClassicDataMap_HighRes::ButtonHome;
-
-
-template<class DataMaps>
-uint8_t ClassicControllerCore<DataMaps>::leftJoyX() const {
+uint8_t ClassicController_Shared::leftJoyX() const {
 	return getControlData(Maps::LeftJoyX);
 }
 
-template<class DataMaps>
-uint8_t ClassicControllerCore<DataMaps>::leftJoyY() const {
+uint8_t ClassicController_Shared::leftJoyY() const {
 	return getControlData(Maps::LeftJoyY);
 }
 
-template<class DataMaps>
-uint8_t ClassicControllerCore<DataMaps>::rightJoyX() const {
+uint8_t ClassicController_Shared::rightJoyX() const {
 	return getControlData(Maps::RightJoyX);
 }
 
-template<class DataMaps>
-uint8_t ClassicControllerCore<DataMaps>::rightJoyY() const {
+uint8_t ClassicController_Shared::rightJoyY() const {
 	return getControlData(Maps::RightJoyY);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::dpadUp() const {
+boolean ClassicController_Shared::dpadUp() const {
 	return getControlBit(Maps::DpadUp);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::dpadDown() const {
+boolean ClassicController_Shared::dpadDown() const {
 	return getControlBit(Maps::DpadDown);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::dpadLeft() const {
+boolean ClassicController_Shared::dpadLeft() const {
 	return getControlBit(Maps::DpadLeft);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::dpadRight() const {
+boolean ClassicController_Shared::dpadRight() const {
 	return getControlBit(Maps::DpadRight);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::buttonA() const {
+boolean ClassicController_Shared::buttonA() const {
 	return getControlBit(Maps::ButtonA);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::buttonB() const {
+boolean ClassicController_Shared::buttonB() const {
 	return getControlBit(Maps::ButtonB);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::buttonX() const {
+boolean ClassicController_Shared::buttonX() const {
 	return getControlBit(Maps::ButtonX);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::buttonY() const {
+boolean ClassicController_Shared::buttonY() const {
 	return getControlBit(Maps::ButtonY);
 }
 
-template<class DataMaps>
-uint8_t ClassicControllerCore<DataMaps>::triggerL() const {
+uint8_t ClassicController_Shared::triggerL() const {
 	return getControlData(Maps::TriggerL);
 }
 
-template<class DataMaps>
-uint8_t ClassicControllerCore<DataMaps>::triggerR() const {
+uint8_t ClassicController_Shared::triggerR() const {
 	return getControlData(Maps::TriggerR);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::buttonL() const {
+boolean ClassicController_Shared::buttonL() const {
 	return getControlBit(Maps::ButtonL);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::buttonR() const {
+boolean ClassicController_Shared::buttonR() const {
 	return getControlBit(Maps::ButtonR);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::buttonZL() const {
+boolean ClassicController_Shared::buttonZL() const {
 	return getControlBit(Maps::ButtonZL);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::buttonZR() const {
+boolean ClassicController_Shared::buttonZR() const {
 	return getControlBit(Maps::ButtonZR);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::buttonStart() const {
+boolean ClassicController_Shared::buttonStart() const {
 	return buttonPlus();
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::buttonSelect() const {
+boolean ClassicController_Shared::buttonSelect() const {
 	return buttonMinus();
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::buttonPlus() const {
+boolean ClassicController_Shared::buttonPlus() const {
 	return getControlBit(Maps::ButtonPlus);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::buttonMinus() const {
+boolean ClassicController_Shared::buttonMinus() const {
 	return getControlBit(Maps::ButtonMinus);
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::buttonHome() const {
+boolean ClassicController_Shared::buttonHome() const {
 	return getControlBit(Maps::ButtonHome);
 }
 
-template<class DataMaps>
-void ClassicControllerCore<DataMaps>::printDebug(Print& output) const {
+void ClassicController_Shared::printDebug(Print& output) const {
 	const char fillCharacter = '_';
 
 	char buffer[62];
@@ -237,17 +181,9 @@ void ClassicControllerCore<DataMaps>::printDebug(Print& output) const {
 	output.println(buffer);
 }
 
-
 // ######### Mini Controller Support #########
 
-boolean ClassicControllerHR_Shared::specificInit() {
-	boolean success = writeRegister(0xFE, 0x03);  // set "high res" mode
-	if (success && getRequestSize() < 8) setRequestSize(8);  // 8 or more bytes of control data needed for this mode
-	return success;
-}
-
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::fixNESThirdPartyData(boolean force) {
+boolean ClassicController_Shared::fixNESThirdPartyData(boolean force) {
 	// Public-facing function to check and "correct" data if using a third party controller
 	// Returns 'true' if data was modified
 	if((isNESThirdParty() && getRequestSize() >= 8) || force == true) {  // 8 bytes is the minimum for valid data
@@ -257,8 +193,7 @@ boolean ClassicControllerCore<DataMaps>::fixNESThirdPartyData(boolean force) {
 	return false;
 }
 
-template<class DataMaps>
-boolean ClassicControllerCore<DataMaps>::isNESThirdParty() const {
+boolean ClassicController_Shared::isNESThirdParty() const {
 	// The third party NES controllers I've come across seem to display the same
 	// unchanging pattern for the first six control bytes:
 	//
@@ -310,8 +245,7 @@ boolean ClassicControllerCore<DataMaps>::isNESThirdParty() const {
 	        getControlData(5) == 0x00);   // Button packet 2 (all pressed)
 }
 
-template<class DataMaps>
-void ClassicControllerCore<DataMaps>::manipulateThirdPartyData() {
+void ClassicController_Shared::manipulateThirdPartyData() {
 	// The data returned by third party NES controllers for the missing control surfaces
 	// (joysticks, triggers, etc.) is "corrupted", meaning that it doesn't align with
 	// what you would expect a Classic Controller at rest to display.
@@ -391,8 +325,5 @@ void SNESMiniController_Shared::printDebug(Print& output) const {
 
 	output.println();
 }
-
-template class ClassicControllerCore<ClassicDataMap_Std>;  // Standard Mappings
-template class ClassicControllerCore<ClassicDataMap_HighRes>;  // "High Resolution" Mappings
 
 }  // End "NintendoExtensionCtrl" namespace

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -26,97 +26,52 @@
 #include "internal/ExtensionController.h"
 
 namespace NintendoExtensionCtrl {
-	struct ClassicDataMap_Std {
-		/* Classic Controller "Standard" Mode
-		 *     7   6   5   4   3   2   1   0
-		 * 0   RX<4:3> LX <5:0>
-		 * 1   RX<2:1> LY <5:0>
-		 * 2   RX<0>   LT<4:3> RY<4:0>
-		 * 3   LT<2:0> RT<4:0>
-		 * 4   BDR BDD BLT B-  BH  B+  BRT 1
-		 * 5   BZL BB  BY  BA  BX  BZR BDL BDU
-		 */
-		constexpr static ByteMap LeftJoyX = ByteMap(0, 6, 0, 0);
-		constexpr static ByteMap LeftJoyY = ByteMap(1, 6, 0, 0);
-
-		constexpr static ByteMap RightJoyX[3] = { ByteMap(0, 2, 6, 3), ByteMap(1, 2, 6, 5), ByteMap(2, 1, 7, 7) };
-		constexpr static ByteMap RightJoyY = ByteMap(2, 5, 0, 0);
-
-		constexpr static BitMap  DpadUp = { 5, 0 };
-		constexpr static BitMap  DpadDown = { 4, 6 };
-		constexpr static BitMap  DpadLeft = { 5, 1 };
-		constexpr static BitMap  DpadRight = { 4, 7 };
-
-		constexpr static BitMap  ButtonA = { 5, 4 };
-		constexpr static BitMap  ButtonB = { 5, 6 };
-		constexpr static BitMap  ButtonX = { 5, 3 };
-		constexpr static BitMap  ButtonY = { 5, 5 };
-
-		constexpr static ByteMap TriggerL[2] = { ByteMap(2, 2, 5, 2), ByteMap(3, 3, 5, 5) };
-		constexpr static ByteMap TriggerR = ByteMap(3, 5, 0, 0);
-
-		constexpr static BitMap  ButtonL = { 4, 5 };
-		constexpr static BitMap  ButtonR = { 4, 1 };
-		constexpr static BitMap  ButtonZL = { 5, 7 };
-		constexpr static BitMap  ButtonZR = { 5, 2 };
-
-		constexpr static BitMap  ButtonPlus = { 4, 2 };
-		constexpr static BitMap  ButtonMinus = { 4, 4 };
-		constexpr static BitMap  ButtonHome = { 4, 3 };
-	};
-
-	struct ClassicDataMap_HighRes {
-		/* Classic Controller "High Resolution" Mode
-		 *     7   6   5   4   3   2   1   0
-		 * 0   LX<7:0>
-		 * 1   RX<7:0>
-		 * 2   LY<7:0>
-		 * 3   RY<7:0>
-		 * 4   LT<7:0>
-		 * 5   RT<7:0>
-		 * 6   BDR BDD BLT B-  BH  B+  BRT 1
-		 * 7   BZL BB  BY  BA  BX  BZR BDL BDU
-		 */
-		constexpr static IndexMap LeftJoyX = 0;
-		constexpr static IndexMap LeftJoyY = 2;
-
-		constexpr static IndexMap RightJoyX = 1;
-		constexpr static IndexMap RightJoyY = 3;
-
-		constexpr static BitMap   DpadUp = { 7, 0 };
-		constexpr static BitMap   DpadDown = { 6, 6 };
-		constexpr static BitMap   DpadLeft = { 7, 1 };
-		constexpr static BitMap   DpadRight = { 6, 7 };
-
-		constexpr static BitMap   ButtonA = { 7, 4 };
-		constexpr static BitMap   ButtonB = { 7, 6 };
-		constexpr static BitMap   ButtonX = { 7, 3 };
-		constexpr static BitMap   ButtonY = { 7, 5 };
-
-		constexpr static IndexMap TriggerL = 4;
-		constexpr static IndexMap TriggerR = 5;
-
-		constexpr static BitMap   ButtonL = { 6, 5 };
-		constexpr static BitMap   ButtonR = { 6, 1 };
-		constexpr static BitMap   ButtonZL = { 7, 7 };
-		constexpr static BitMap   ButtonZR = { 7, 2 };
-
-		constexpr static BitMap   ButtonPlus = { 6, 2 };
-		constexpr static BitMap   ButtonMinus = { 6, 4 };
-		constexpr static BitMap   ButtonHome = { 6, 3 };
-	};
-
-
-	template<class DataMaps>
-	class ClassicControllerCore : public ExtensionController {
+	class ClassicController_Shared : public ExtensionController {
 	public:
-		ClassicControllerCore(ExtensionData &dataRef) :
+		struct Maps {
+			/* Classic Controller "Standard" Mode
+			 *     7   6   5   4   3   2   1   0
+			 * 0   RX<4:3> LX <5:0>
+			 * 1   RX<2:1> LY <5:0>
+			 * 2   RX<0>   LT<4:3> RY<4:0>
+			 * 3   LT<2:0> RT<4:0>
+			 * 4   BDR BDD BLT B-  BH  B+  BRT 1
+			 * 5   BZL BB  BY  BA  BX  BZR BDL BDU
+			 */
+			constexpr static ByteMap LeftJoyX = ByteMap(0, 6, 0, 0);
+			constexpr static ByteMap LeftJoyY = ByteMap(1, 6, 0, 0);
+
+			constexpr static ByteMap RightJoyX[3] = { ByteMap(0, 2, 6, 3), ByteMap(1, 2, 6, 5), ByteMap(2, 1, 7, 7) };
+			constexpr static ByteMap RightJoyY = ByteMap(2, 5, 0, 0);
+
+			constexpr static BitMap  DpadUp = { 5, 0 };
+			constexpr static BitMap  DpadDown = { 4, 6 };
+			constexpr static BitMap  DpadLeft = { 5, 1 };
+			constexpr static BitMap  DpadRight = { 4, 7 };
+
+			constexpr static BitMap  ButtonA = { 5, 4 };
+			constexpr static BitMap  ButtonB = { 5, 6 };
+			constexpr static BitMap  ButtonX = { 5, 3 };
+			constexpr static BitMap  ButtonY = { 5, 5 };
+
+			constexpr static ByteMap TriggerL[2] = { ByteMap(2, 2, 5, 2), ByteMap(3, 3, 5, 5) };
+			constexpr static ByteMap TriggerR = ByteMap(3, 5, 0, 0);
+
+			constexpr static BitMap  ButtonL = { 4, 5 };
+			constexpr static BitMap  ButtonR = { 4, 1 };
+			constexpr static BitMap  ButtonZL = { 5, 7 };
+			constexpr static BitMap  ButtonZR = { 5, 2 };
+
+			constexpr static BitMap  ButtonPlus = { 4, 2 };
+			constexpr static BitMap  ButtonMinus = { 4, 4 };
+			constexpr static BitMap  ButtonHome = { 4, 3 };
+		};
+
+		ClassicController_Shared(ExtensionData &dataRef) :
 			ExtensionController(dataRef, ExtensionType::ClassicController) {}
 
-		ClassicControllerCore(ExtensionPort &port) :
-			ClassicControllerCore(port.getExtensionData()) {}
-
-		using Maps = DataMaps;  // save from template
+		ClassicController_Shared(ExtensionPort &port) :
+			ClassicController_Shared(port.getExtensionData()) {}
 
 		uint8_t leftJoyX() const;  // 6 bits, 0-63
 		uint8_t leftJoyY() const;
@@ -162,16 +117,6 @@ namespace NintendoExtensionCtrl {
 		void manipulateThirdPartyData();
 	};
 
-	using ClassicController_Shared = ClassicControllerCore<ClassicDataMap_Std>;  // Classic Controller w/ Standard Mapping
-
-
-	class ClassicControllerHR_Shared : public ClassicControllerCore<ClassicDataMap_HighRes> {
-		using ClassicControllerCore<ClassicDataMap_HighRes>::ClassicControllerCore;
-
-		boolean specificInit();
-	};
-
-
 	class NESMiniController_Shared : public ClassicController_Shared {
 	public:
 		using ClassicController_Shared::ClassicController_Shared;
@@ -192,9 +137,6 @@ namespace NintendoExtensionCtrl {
 
 using ClassicController = NintendoExtensionCtrl::BuildControllerClass
 	<NintendoExtensionCtrl::ClassicController_Shared>;
-
-using ClassicControllerHR = NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::ClassicControllerHR_Shared>;
 
 using NESMiniController = NintendoExtensionCtrl::BuildControllerClass
 	<NintendoExtensionCtrl::NESMiniController_Shared>;

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -152,29 +152,30 @@ namespace NintendoExtensionCtrl {
 
 		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 
-	// 3rd Party NES Controller Support
-	public:
-		boolean isNESThirdParty() const;
-		boolean fixNESThirdPartyData(boolean force = false);
-
 	protected:
-		void manipulateThirdPartyData();
 		boolean highRes = false;  // 'high resolution' mode setting
 	};
 
-	class NESMiniController_Shared : public ClassicController_Shared {
+
+	/* Nintendo Mini Console Controllers */
+
+	class MiniControllerBase : public ClassicController_Shared {
 	public:
 		using ClassicController_Shared::ClassicController_Shared;
 
-		boolean isThirdParty() const { return isNESThirdParty(); }
-		boolean fixThirdPartyData(boolean force = false) { return fixNESThirdPartyData(force); }
+		boolean specificInit();
+	};
+
+	class NESMiniController_Shared : public MiniControllerBase {
+	public:
+		using MiniControllerBase::MiniControllerBase;
 
 		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 	};
 
-	class SNESMiniController_Shared : public ClassicController_Shared {
+	class SNESMiniController_Shared : public MiniControllerBase {
 	public:
-		using ClassicController_Shared::ClassicController_Shared;
+		using MiniControllerBase::MiniControllerBase;
 
 		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 	};

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -67,11 +67,55 @@ namespace NintendoExtensionCtrl {
 			constexpr static BitMap  ButtonHome = { 4, 3 };
 		};
 
+		struct MapsHR {
+			/* Classic Controller "High Resolution" Mode
+			 *     7   6   5   4   3   2   1   0
+			 * 0   LX<7:0>
+			 * 1   RX<7:0>
+			 * 2   LY<7:0>
+			 * 3   RY<7:0>
+			 * 4   LT<7:0>
+			 * 5   RT<7:0>
+			 * 6   BDR BDD BLT B-  BH  B+  BRT 1
+			 * 7   BZL BB  BY  BA  BX  BZR BDL BDU
+			 */
+			constexpr static IndexMap LeftJoyX = 0;
+			constexpr static IndexMap LeftJoyY = 2;
+
+			constexpr static IndexMap RightJoyX = 1;
+			constexpr static IndexMap RightJoyY = 3;
+
+			constexpr static BitMap   DpadUp = { 7, 0 };
+			constexpr static BitMap   DpadDown = { 6, 6 };
+			constexpr static BitMap   DpadLeft = { 7, 1 };
+			constexpr static BitMap   DpadRight = { 6, 7 };
+
+			constexpr static BitMap   ButtonA = { 7, 4 };
+			constexpr static BitMap   ButtonB = { 7, 6 };
+			constexpr static BitMap   ButtonX = { 7, 3 };
+			constexpr static BitMap   ButtonY = { 7, 5 };
+
+			constexpr static IndexMap TriggerL = 4;
+			constexpr static IndexMap TriggerR = 5;
+
+			constexpr static BitMap   ButtonL = { 6, 5 };
+			constexpr static BitMap   ButtonR = { 6, 1 };
+			constexpr static BitMap   ButtonZL = { 7, 7 };
+			constexpr static BitMap   ButtonZR = { 7, 2 };
+
+			constexpr static BitMap   ButtonPlus = { 6, 2 };
+			constexpr static BitMap   ButtonMinus = { 6, 4 };
+			constexpr static BitMap   ButtonHome = { 6, 3 };
+		};
+
 		ClassicController_Shared(ExtensionData &dataRef) :
 			ExtensionController(dataRef, ExtensionType::ClassicController) {}
 
 		ClassicController_Shared(ExtensionPort &port) :
 			ClassicController_Shared(port.getExtensionData()) {}
+
+		boolean setHighRes(boolean hr = true);
+		boolean getHighRes() const;
 
 		uint8_t leftJoyX() const;  // 6 bits, 0-63
 		uint8_t leftJoyY() const;
@@ -115,6 +159,7 @@ namespace NintendoExtensionCtrl {
 
 	protected:
 		void manipulateThirdPartyData();
+		boolean highRes = false;  // 'high resolution' mode setting
 	};
 
 	class NESMiniController_Shared : public ClassicController_Shared {

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -66,15 +66,16 @@ namespace NintendoExtensionCtrl {
 	};
 
 
-	class ClassicController_Shared : public ExtensionController {
+	template<class DataMaps>
+	class ClassicControllerCore : public ExtensionController {
 	public:
-		ClassicController_Shared(ExtensionData &dataRef) :
+		ClassicControllerCore(ExtensionData &dataRef) :
 			ExtensionController(dataRef, ExtensionType::ClassicController) {}
 
-		ClassicController_Shared(ExtensionPort &port) :
-			ClassicController_Shared(port.getExtensionData()) {}
+		ClassicControllerCore(ExtensionPort &port) :
+			ClassicControllerCore(port.getExtensionData()) {}
 
-		using Maps = ClassicDataMap_Std;
+		using Maps = DataMaps;  // save from template
 
 		uint8_t leftJoyX() const;  // 6 bits, 0-63
 		uint8_t leftJoyY() const;
@@ -119,6 +120,9 @@ namespace NintendoExtensionCtrl {
 	protected:
 		void manipulateThirdPartyData();
 	};
+
+	using ClassicController_Shared = ClassicControllerCore<ClassicDataMap_Std>;  // Classic Controller w/ Standard Mapping
+
 
 	class NESMiniController_Shared : public ClassicController_Shared {
 	public:

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -65,6 +65,47 @@ namespace NintendoExtensionCtrl {
 		constexpr static BitMap  ButtonHome = { 4, 3 };
 	};
 
+	struct ClassicDataMap_HighRes {
+		/* Classic Controller "High Resolution" Mode
+		 *     7   6   5   4   3   2   1   0
+		 * 0   LX<7:0>
+		 * 1   RX<7:0>
+		 * 2   LY<7:0>
+		 * 3   RY<7:0>
+		 * 4   LT<7:0>
+		 * 5   RT<7:0>
+		 * 6   BDR BDD BLT B-  BH  B+  BRT 1
+		 * 7   BZL BB  BY  BA  BX  BZR BDL BDU
+		 */
+		constexpr static IndexMap LeftJoyX = 0;
+		constexpr static IndexMap LeftJoyY = 2;
+
+		constexpr static IndexMap RightJoyX = 1;
+		constexpr static IndexMap RightJoyY = 3;
+
+		constexpr static BitMap   DpadUp = { 7, 0 };
+		constexpr static BitMap   DpadDown = { 6, 6 };
+		constexpr static BitMap   DpadLeft = { 7, 1 };
+		constexpr static BitMap   DpadRight = { 6, 7 };
+
+		constexpr static BitMap   ButtonA = { 7, 4 };
+		constexpr static BitMap   ButtonB = { 7, 6 };
+		constexpr static BitMap   ButtonX = { 7, 3 };
+		constexpr static BitMap   ButtonY = { 7, 5 };
+
+		constexpr static IndexMap TriggerL = 4;
+		constexpr static IndexMap TriggerR = 5;
+
+		constexpr static BitMap   ButtonL = { 6, 5 };
+		constexpr static BitMap   ButtonR = { 6, 1 };
+		constexpr static BitMap   ButtonZL = { 7, 7 };
+		constexpr static BitMap   ButtonZR = { 7, 2 };
+
+		constexpr static BitMap   ButtonPlus = { 6, 2 };
+		constexpr static BitMap   ButtonMinus = { 6, 4 };
+		constexpr static BitMap   ButtonHome = { 6, 3 };
+	};
+
 
 	template<class DataMaps>
 	class ClassicControllerCore : public ExtensionController {
@@ -124,6 +165,13 @@ namespace NintendoExtensionCtrl {
 	using ClassicController_Shared = ClassicControllerCore<ClassicDataMap_Std>;  // Classic Controller w/ Standard Mapping
 
 
+	class ClassicControllerHR_Shared : public ClassicControllerCore<ClassicDataMap_HighRes> {
+		using ClassicControllerCore<ClassicDataMap_HighRes>::ClassicControllerCore;
+
+		boolean specificInit();
+	};
+
+
 	class NESMiniController_Shared : public ClassicController_Shared {
 	public:
 		using ClassicController_Shared::ClassicController_Shared;
@@ -144,6 +192,9 @@ namespace NintendoExtensionCtrl {
 
 using ClassicController = NintendoExtensionCtrl::BuildControllerClass
 	<NintendoExtensionCtrl::ClassicController_Shared>;
+
+using ClassicControllerHR = NintendoExtensionCtrl::BuildControllerClass
+	<NintendoExtensionCtrl::ClassicControllerHR_Shared>;
 
 using NESMiniController = NintendoExtensionCtrl::BuildControllerClass
 	<NintendoExtensionCtrl::NESMiniController_Shared>;

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -26,52 +26,55 @@
 #include "internal/ExtensionController.h"
 
 namespace NintendoExtensionCtrl {
+	struct ClassicDataMap_Std {
+		/* Classic Controller "Standard" Mode
+		 *     7   6   5   4   3   2   1   0
+		 * 0   RX<4:3> LX <5:0>
+		 * 1   RX<2:1> LY <5:0>
+		 * 2   RX<0>   LT<4:3> RY<4:0>
+		 * 3   LT<2:0> RT<4:0>
+		 * 4   BDR BDD BLT B-  BH  B+  BRT 1
+		 * 5   BZL BB  BY  BA  BX  BZR BDL BDU
+		 */
+		constexpr static ByteMap LeftJoyX = ByteMap(0, 6, 0, 0);
+		constexpr static ByteMap LeftJoyY = ByteMap(1, 6, 0, 0);
+
+		constexpr static ByteMap RightJoyX[3] = { ByteMap(0, 2, 6, 3), ByteMap(1, 2, 6, 5), ByteMap(2, 1, 7, 7) };
+		constexpr static ByteMap RightJoyY = ByteMap(2, 5, 0, 0);
+
+		constexpr static BitMap  DpadUp = { 5, 0 };
+		constexpr static BitMap  DpadDown = { 4, 6 };
+		constexpr static BitMap  DpadLeft = { 5, 1 };
+		constexpr static BitMap  DpadRight = { 4, 7 };
+
+		constexpr static BitMap  ButtonA = { 5, 4 };
+		constexpr static BitMap  ButtonB = { 5, 6 };
+		constexpr static BitMap  ButtonX = { 5, 3 };
+		constexpr static BitMap  ButtonY = { 5, 5 };
+
+		constexpr static ByteMap TriggerL[2] = { ByteMap(2, 2, 5, 2), ByteMap(3, 3, 5, 5) };
+		constexpr static ByteMap TriggerR = ByteMap(3, 5, 0, 0);
+
+		constexpr static BitMap  ButtonL = { 4, 5 };
+		constexpr static BitMap  ButtonR = { 4, 1 };
+		constexpr static BitMap  ButtonZL = { 5, 7 };
+		constexpr static BitMap  ButtonZR = { 5, 2 };
+
+		constexpr static BitMap  ButtonPlus = { 4, 2 };
+		constexpr static BitMap  ButtonMinus = { 4, 4 };
+		constexpr static BitMap  ButtonHome = { 4, 3 };
+	};
+
+
 	class ClassicController_Shared : public ExtensionController {
 	public:
-		struct Maps {
-			/* Classic Controller "Standard" Mode
-			 *     7   6   5   4   3   2   1   0
-			 * 0   RX<4:3> LX <5:0>
-			 * 1   RX<2:1> LY <5:0>
-			 * 2   RX<0>   LT<4:3> RY<4:0>
-			 * 3   LT<2:0> RT<4:0>
-			 * 4   BDR BDD BLT B-  BH  B+  BRT 1
-			 * 5   BZL BB  BY  BA  BX  BZR BDL BDU
-			 */
-			constexpr static ByteMap LeftJoyX = ByteMap(0, 6, 0, 0);
-			constexpr static ByteMap LeftJoyY = ByteMap(1, 6, 0, 0);
-
-			constexpr static ByteMap RightJoyX[3] = { ByteMap(0, 2, 6, 3), ByteMap(1, 2, 6, 5), ByteMap(2, 1, 7, 7) };
-			constexpr static ByteMap RightJoyY = ByteMap(2, 5, 0, 0);
-
-			constexpr static BitMap  DpadUp = { 5, 0 };
-			constexpr static BitMap  DpadDown = { 4, 6 };
-			constexpr static BitMap  DpadLeft = { 5, 1 };
-			constexpr static BitMap  DpadRight = { 4, 7 };
-
-			constexpr static BitMap  ButtonA = { 5, 4 };
-			constexpr static BitMap  ButtonB = { 5, 6 };
-			constexpr static BitMap  ButtonX = { 5, 3 };
-			constexpr static BitMap  ButtonY = { 5, 5 };
-
-			constexpr static ByteMap TriggerL[2] = { ByteMap(2, 2, 5, 2), ByteMap(3, 3, 5, 5) };
-			constexpr static ByteMap TriggerR = ByteMap(3, 5, 0, 0);
-
-			constexpr static BitMap  ButtonL = { 4, 5 };
-			constexpr static BitMap  ButtonR = { 4, 1 };
-			constexpr static BitMap  ButtonZL = { 5, 7 };
-			constexpr static BitMap  ButtonZR = { 5, 2 };
-
-			constexpr static BitMap  ButtonPlus = { 4, 2 };
-			constexpr static BitMap  ButtonMinus = { 4, 4 };
-			constexpr static BitMap  ButtonHome = { 4, 3 };
-		};
-
 		ClassicController_Shared(ExtensionData &dataRef) :
 			ExtensionController(dataRef, ExtensionType::ClassicController) {}
 
 		ClassicController_Shared(ExtensionPort &port) :
 			ClassicController_Shared(port.getExtensionData()) {}
+
+		using Maps = ClassicDataMap_Std;
 
 		uint8_t leftJoyX() const;  // 6 bits, 0-63
 		uint8_t leftJoyY() const;

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -29,6 +29,15 @@ namespace NintendoExtensionCtrl {
 	class ClassicController_Shared : public ExtensionController {
 	public:
 		struct Maps {
+			/* Classic Controller "Standard" Mode
+			 *     7   6   5   4   3   2   1   0
+			 * 0   RX<4:3> LX <5:0>
+			 * 1   RX<2:1> LY <5:0>
+			 * 2   RX<0>   LT<4:3> RY<4:0>
+			 * 3   LT<2:0> RT<4:0>
+			 * 4   BDR BDD BLT B-  BH  B+  BRT 1
+			 * 5   BZL BB  BY  BA  BX  BZR BDL BDU
+			 */
 			constexpr static ByteMap LeftJoyX = ByteMap(0, 6, 0, 0);
 			constexpr static ByteMap LeftJoyY = ByteMap(1, 6, 0, 0);
 

--- a/src/internal/NXC_Identity.h
+++ b/src/internal/NXC_Identity.h
@@ -47,9 +47,15 @@ namespace NintendoExtensionCtrl {
 				return ExtensionType::Nunchuk;
 			}
 
-			// Classic Con. ID: 0x0101 (Std) or 0x0301 (HighRes)
-			else if ((idData[4] == 0x01 && idData[5] == 0x01)
-				|| (idData[4] == 0x03 && idData[5] == 0x01)) {
+			/* Classic Con. ID: 0x0[01] 0x00 0xA4 0x20 0x## 0x01
+			 *   Where ## =
+			 *     0x00 - Double initialized. (shouldn't happen in normal use)
+			 *     0x01 - Standard data mode
+			 *     0x02 - ??? Reports data, but not in a known format
+			 *     0x03 - "High resolution" mode, used by mini consoles
+			 */
+			else if (idData[0] <= 0x01 && idData[1] == 0x00
+				  && idData[4] <= 0x03 && idData[5] == 0x01) {
 				return ExtensionType::ClassicController;
 			}
 

--- a/src/internal/NXC_Identity.h
+++ b/src/internal/NXC_Identity.h
@@ -41,13 +41,15 @@ enum class ExtensionType {
 namespace NintendoExtensionCtrl {
 	inline ExtensionType decodeIdentity(const uint8_t * idData) {
 		if (idData[2] == 0xA4 && idData[3] == 0x20) {  // All valid IDs
+
 			// Nunchuk ID: 0x0000
 			if (idData[4] == 0x00 && idData[5] == 0x00) {
 				return ExtensionType::Nunchuk;
 			}
 
-			// Classic Con. ID: 0x0101
-			else if (idData[4] == 0x01 && idData[5] == 0x01) {
+			// Classic Con. ID: 0x0101 (Std) or 0x0301 (HighRes)
+			else if ((idData[4] == 0x01 && idData[5] == 0x01)
+				|| (idData[4] == 0x03 && idData[5] == 0x01)) {
 				return ExtensionType::ClassicController;
 			}
 
@@ -68,6 +70,7 @@ namespace NintendoExtensionCtrl {
 					return ExtensionType::DJTurntableController;
 				}
 			}
+
 			// uDraw Tablet Con. ID: 0x0112
 			else if (idData[4] == 0x01 && idData[5] == 0x12) {
 				return ExtensionType::uDrawTablet;


### PR DESCRIPTION
Adds "high resolution" mode support to the Classic Controller class. In this mode, the master (Arduino) makes an 8-byte request instead of a 6-byte one, and the controller uses these two extra bytes to report the joystick and trigger data as full bytes (0-255). This mode is set by writing `0x03` to register `0xFE`, and disabled by writing `0x01`. See #60 for more information on the data format.

This mode also improves the functionality of poorly designed "knockoff" NES controllers, which default to this mode whether it is set by the host or not. The `NESMiniController` and `SNESMiniController` classes will use the "high resolution" mode by default, set on connection. This matches the behavior of the "Mini" consoles, albeit without the full 21 byte OR request to check for data corruption. As this is the proper way to support this data format, the `isNESThirdParty` and `fixNESThirdParty` functions have been removed.

To demonstrate this new data mode, I've added a new example called "Classic_HighRes". This example is a rewrite of the typical "DebugPrint" example that automatically switches between the "standard" and "high resolution" data modes every 6 seconds. I've also added comments to the other Classic Controller examples to indicate the analog ranges of the high resolution mode.

Last but not least, this PR makes the `decodeIdentity` function more robust for Classic Controllers by ignoring the register used for the resolution setting (`0xFE`, # 5/6 in the ID string). This should fix the issue where Classic Controllers do not identify properly when the microcontroller is reset while the controller is still connected and powered (#51).

This completes the loop for #37:

> Somewhere in the world a company thought that these controllers worked fine and decided to sell them. From what I can see looking at reviews for 3rd party NES Mini controllers, most of them are reported to not work. But, there is likely some sort of middle ground - some group of settings or I²C requests that allows these controllers to communicate "properly" like a Classic Controller. I just have no idea what it is.

\- Me, Dec 2, 2018

A big thanks to @nullstalgia for uncovering this. Closes #60.

---

My first shot at this was to rewrite the Classic Controller class to use template metaprogramming so that the base class could take a template argument for the data maps to use. Then the "Standard" and "High Resolution" versions of the controllers were made as separate classes, and the user would need to decide at the beginning of the program which version to use.

This *worked*, but it was clunky. The classes were identical except for the data maps used, and I couldn't create a common base class to swap between the mappings without the overhead from a vtable for each function. If the user wanted to use both a Classic Controller and an NES controller they would have to create two separate instances with two separate classes for what are, logically and possibly physically, the same device. This code is still in the commit history but was reverted (123d067).

This submitted version is not nearly as lightweight (the high res mode value is checked in every control function), but it is much more flexible and cleaner for the end user. The "high resolution" mode can be toggled on and off at will and the functions will automatically switch to return the proper mappings. This also keeps the `ClassicController` class as a single logical entity, which is better for organization and keeping in the logical structure of the library (one controller = one class).