### PR TITLE
[UNTESTED] - Taiko no Tatsujin Drum Controller (Tatacon) support

### DIFF
--- a/examples/Any/IdentifyController/IdentifyController.ino
+++ b/examples/Any/IdentifyController/IdentifyController.ino
@@ -63,6 +63,9 @@ void setup() {
 		case(ExtensionType::DrawsomeTablet):
 			Serial.println("Drawsome Tablet connected!");
 			break;
+        case(ExtensionType::Tatacon):
+            Serial.println("Tatacon drum connected!");
+            break;
 		default: break;
 	}
 	controller.printDebugID();

--- a/examples/Any/IdentifyController/IdentifyController.ino
+++ b/examples/Any/IdentifyController/IdentifyController.ino
@@ -63,9 +63,9 @@ void setup() {
 		case(ExtensionType::DrawsomeTablet):
 			Serial.println("Drawsome Tablet connected!");
 			break;
-        case(ExtensionType::Tatacon):
-            Serial.println("Tatacon drum connected!");
-            break;
+		case(ExtensionType::Tatacon):
+			Serial.println("Tatacon drum connected!");
+			break;
 		default: break;
 	}
 	controller.printDebugID();

--- a/examples/Tatacon/Tatacon_DebugPrint/Tatacon_DebugPrint.ino
+++ b/examples/Tatacon/Tatacon_DebugPrint/Tatacon_DebugPrint.ino
@@ -1,8 +1,8 @@
 /*
 *  Project     Nintendo Extension Controller Library
-*  @author     David Madison
+*  @author     Nullstalgia
 *  @link       github.com/dmadison/NintendoExtensionCtrl
-*  @license    LGPLv3 - Copyright (c) 2018 David Madison
+*  @license    LGPLv3 - Copyright (c) 2020 Nullstalgia
 *
 *  This file is part of the Nintendo Extension Controller Library.
 *
@@ -18,26 +18,35 @@
 *
 *  You should have received a copy of the GNU Lesser General Public License
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*  Example:      Tatacon_DebugPrint
+*  Description:  Connect to a Tatacon and continuously print its control
+*                data, nicely formatted for debugging, over the serial bus.
 */
 
-#ifndef NintendoExtensionCtrl_h
-#define NintendoExtensionCtrl_h
+#include <NintendoExtensionCtrl.h>
 
-// Controller Base
-#include "internal/ExtensionController.h"
+Tatacon drum;
 
-// Wii Controllers
-#include "controllers/Nunchuk.h"
-#include "controllers/ClassicController.h"
-#include "controllers/GuitarController.h"
-#include "controllers/DrumController.h"
-#include "controllers/DJTurntable.h"
-#include "controllers/uDrawTablet.h"
-#include "controllers/DrawsomeTablet.h"
-#include "controllers/Tatacon.h"
+void setup() {
+	Serial.begin(115200);
+	drum.begin();
 
+	while (!drum.connect()) {
+		Serial.println("Tatacon not detected!");
+		delay(1000);
+	}
+}
 
-// Mini Controllers
-/* (included with ClassicController.h) */
+void loop() {
+	boolean success = drum.update();  // Get new data from the controller
 
-#endif
+	if (success == true) {  // We've got data!
+		drum.printDebug();  // Print all of the values!
+	}
+	else {  // Data is bad :(
+		Serial.println("Controller Disconnected!");
+		delay(1000);
+		drum.connect();
+	}
+}

--- a/examples/Tatacon/Tatacon_Demo/Tatacon_Demo.ino
+++ b/examples/Tatacon/Tatacon_Demo/Tatacon_Demo.ino
@@ -1,0 +1,99 @@
+/*
+*  Project     Nintendo Extension Controller Library
+*  @author     Nullstalgia
+*  @link       github.com/dmadison/NintendoExtensionCtrl
+*  @license    LGPLv3 - Copyright (c) 2020 Nullstalgia
+*
+*  This file is part of the Nintendo Extension Controller Library.
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Lesser General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Lesser General Public License for more details.
+*
+*  You should have received a copy of the GNU Lesser General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*  Example:      Tatacon_Demo
+*  Description:  Connect to a Tatacon and demonstrate all of the avaiable
+*                control data functions.
+*/
+
+#include <NintendoExtensionCtrl.h>
+
+Tatacon drum;
+
+unsigned long lastLeftDon;
+unsigned long lastRightDon;
+
+unsigned long lastLeftKa;
+unsigned long lastRightKa;
+
+#define LARGE_NOTE_TIMING 100
+
+void setup() {
+	Serial.begin(115200);
+	drum.begin();
+
+	while (!drum.connect()) {
+		Serial.println("Tatacon not detected!");
+		delay(1000);
+	}
+}
+
+void loop() {
+	Serial.println("----- Tatacon Demo -----"); // Making things easier to read
+	boolean success = drum.update();  // Get new data from the controller
+
+	if (!success) {  // Ruh roh
+		Serial.println("Controller disconnected!");
+		delay(1000);
+	}
+	else {
+		unsigned long currentMillis = millis();
+		
+		if (drum.centerLeft()) {
+			if (currentMillis - lastRightDon <= LARGE_NOTE_TIMING) {
+				lastLeftDon = currentMillis;
+				Serial.println("DON!");
+			} else {
+				Serial.println("Don");
+			}
+		}
+		
+		if (drum.centerRight()) {
+			if (currentMillis - lastLeftDon <= LARGE_NOTE_TIMING) {
+				lastRightDon = currentMillis;
+				Serial.println("DON!");
+			} else {
+				Serial.println("Don");
+			}
+		}
+		
+		if (drum.rimLeft()) {
+			if (currentMillis - lastRightKa <= LARGE_NOTE_TIMING) {
+				lastLeftKa = currentMillis;
+				Serial.println("KA!");
+			} else {
+				Serial.println("Ka");
+			}
+		}
+		
+		if (drum.rimRight()) {
+			if (currentMillis - lastLeftKa <= LARGE_NOTE_TIMING) {
+				lastRightKa = currentMillis;
+				Serial.println("KA!");
+			} else {
+				Serial.println("Ka");
+			}
+		}
+
+		// Print all the values!
+		drum.printDebug();
+	}
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -21,6 +21,7 @@ DrumController	KEYWORD1
 DJTurntableController	KEYWORD1
 uDrawTablet	 KEYWORD1
 DrawsomeTablet	KEYWORD1
+Tatacon	 KEYWORD1
 
 # Mini Controllers
 NESMiniController	KEYWORD1
@@ -223,6 +224,11 @@ buttonUpper	 KEYWORD2
 ## Drawsome Tablet
 # (Covered by the uDrawTablet keywords)
 
+## Tatacon
+centerLeft	KEYWORD2
+centerRight	KEYWORD2
+rimLeft	    KEYWORD2
+rimRight	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=Nintendo Extension Ctrl
-version=0.8.1
+version=0.8.2
 author=David Madison
 maintainer=David Madison
 sentence=Library for talking to Nintendo extension controllers over I2C.
-paragraph=Supports the Wii Nunchuk, Wii Classic Controller, Guitar Hero guitar, Guitar Hero drum set, DJ Hero turntable, S/NES Mini controllers, Drawsome Tablet, and the uDraw Tablet.
+paragraph=Supports the Wii Nunchuk, Wii Classic Controller, Guitar Hero guitar, Guitar Hero drum set, DJ Hero turntable, S/NES Mini controllers, Drawsome Tablet, the uDraw Tablet, and Tatacon Drum controllers.
 category=Communication
 url=https://github.com/dmadison/NintendoExtensionCtrl
 architectures=*

--- a/src/controllers/Tatacon.cpp
+++ b/src/controllers/Tatacon.cpp
@@ -66,7 +66,7 @@ void Tatacon_Shared::printDebug(Print& output) const {
 
 	output.print("Nunchuk - ");
 	sprintf(buffer,
-            "Center: (Left: %c  Right: %C) | Rim: (Left: %c  Right: %c)",
+            "Center: (Left: %c  Right: %c) | Rim: (Left: %c  Right: %c)",
 			donPrintL, donPrintR, kaPrintL, kaPrintR);
 
 	output.println(buffer);

--- a/src/controllers/Tatacon.cpp
+++ b/src/controllers/Tatacon.cpp
@@ -1,0 +1,75 @@
+/*
+*  Project     Nintendo Extension Controller Library
+*  @author     Nullstalgia
+*  @link       github.com/dmadison/NintendoExtensionCtrl
+*  @license    LGPLv3 - Copyright (c) 2020 Nullstalgia
+*
+*  This file is part of the Nintendo Extension Controller Library.
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Lesser General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Lesser General Public License for more details.
+*
+*  You should have received a copy of the GNU Lesser General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "Tatacon.h"
+
+namespace NintendoExtensionCtrl {
+
+constexpr BitMap   Tatacon_Shared::Maps::CenterLeft;
+constexpr BitMap   Tatacon_Shared::Maps::CenterRight;
+
+constexpr BitMap   Tatacon_Shared::Maps::RimLeft;
+constexpr BitMap   Tatacon_Shared::Maps::RimRight;
+
+boolean Tatacon_Shared::specificInit() {
+	/* It uses only 4 bits in the first byte,
+	 * so this is to limit wasted time reading the 
+	 * remaining empty, unchanging, bytes.
+	 */
+	setRequestSize(1);
+	return true;
+}
+
+boolean Tatacon_Shared::CenterLeft() const {
+	return getControlBit(Maps::CenterLeft);
+}
+
+boolean Tatacon_Shared::CenterRight() const {
+	return getControlBit(Maps::CenterRight);
+}
+
+boolean Tatacon_Shared::RimLeft() const {
+	return getControlBit(Maps::RimLeft);
+}
+
+boolean Tatacon_Shared::RimRight() const {
+	return getControlBit(Maps::RimRight);
+}
+
+void Tatacon_Shared::printDebug(Print& output) const {
+	char buffer[60];
+
+	char donPrintL = CenterLeft() ? 'D' : '-';
+	char donPrintR = CenterRight() ? 'D' : '-';
+	
+	char kaPrintL = RimLeft() ? 'K' : '-';
+	char kaPrintR = RimRight() ? 'K' : '-';
+
+	output.print("Nunchuk - ");
+	sprintf(buffer,
+            "Center: (Left: %c  Right: %C) | Rim: (Left: %c  Right: %c)",
+			donPrintL, donPrintR, kaPrintL, kaPrintR);
+
+	output.println(buffer);
+}
+
+}  // End "NintendoExtensionCtrl" namespace

--- a/src/controllers/Tatacon.h
+++ b/src/controllers/Tatacon.h
@@ -1,0 +1,59 @@
+/*
+*  Project     Nintendo Extension Controller Library
+*  @author     Nullstalgia
+*  @link       github.com/dmadison/NintendoExtensionCtrl
+*  @license    LGPLv3 - Copyright (c) 2020 Nullstalgia
+*
+*  This file is part of the Nintendo Extension Controller Library.
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Lesser General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Lesser General Public License for more details.
+*
+*  You should have received a copy of the GNU Lesser General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NXC_Tatacon_h
+#define NXC_Tatacon_h
+
+#include "internal/ExtensionController.h"
+
+namespace NintendoExtensionCtrl {
+	class Tatacon_Shared : public ExtensionController {
+	public:
+		struct Maps {
+			constexpr static BitMap   CenterLeft = { 0, 6 };
+			constexpr static BitMap   CenterRight = { 0, 4 };
+			constexpr static BitMap   RimLeft = { 0, 5 };
+			constexpr static BitMap   RimRight = { 0, 3 };
+		};
+		
+		Tatacon_Shared(ExtensionData &dataRef) :
+			ExtensionController(dataRef, ExtensionType::Tatacon) {}
+
+		Tatacon_Shared(ExtensionPort &port) :
+			Tatacon_Shared(port.getExtensionData()) {}
+			
+		boolean specificInit();
+
+		boolean CenterLeft() const; // ドン !!
+		boolean CenterRight() const; // ヽ（゜∀゜○）ノ
+	
+		boolean RimLeft() const; // カッ !!
+		boolean RimRight() const; // ヽ(。ゝω・)ノ☆
+
+		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
+	};
+}
+
+using Tatacon = NintendoExtensionCtrl::BuildControllerClass
+	<NintendoExtensionCtrl::Tatacon_Shared>;
+
+#endif

--- a/src/internal/NXC_Identity.h
+++ b/src/internal/NXC_Identity.h
@@ -35,7 +35,8 @@ enum class ExtensionType {
 	DrumController,
 	DJTurntableController,
 	uDrawTablet,
-	DrawsomeTablet
+	DrawsomeTablet,
+	Tatacon
 };
 
 namespace NintendoExtensionCtrl {
@@ -76,7 +77,7 @@ namespace NintendoExtensionCtrl {
 					return ExtensionType::DJTurntableController;
 				}
 			}
-
+			
 			// uDraw Tablet Con. ID: 0x0112
 			else if (idData[4] == 0x01 && idData[5] == 0x12) {
 				return ExtensionType::uDrawTablet;
@@ -84,6 +85,11 @@ namespace NintendoExtensionCtrl {
 			// Drawsome Tablet Con. ID: 0x0013
 			else if (idData[4] == 0x00 && idData[5] == 0x13) {
 				return ExtensionType::DrawsomeTablet;
+			}
+			
+			// Taiko no Tatsujin Tatacon Con. ID: 0x0111
+			else if (idData[4] == 0x01 && idData[5] == 0x11) {
+				return ExtensionType::Tatacon;
 			}
 		}
 


### PR DESCRIPTION
Heyo.

Based on: [http://wiibrew.org/wiki/Wiimote/Extension_Controllers/TaTaCon](http://wiibrew.org/wiki/Wiimote/Extension_Controllers/TaTaCon)

[https://github.com/mon/TataconUSB](https://github.com/mon/TataconUSB)

Is currently untested, and will remain so until my drum arrives. :)