### PR TITLE
Fix for Classic Controller clones without data mode support

### DIFF
--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -159,14 +159,13 @@ boolean ClassicController_Shared::checkDataMode(boolean *hr) const {
 	 * register-based I2C device and just return junk. So instead we're starting
 	 * at the beginning of the data block.
 	 */
-	static const uint8_t CheckPtr   = 0x00;  // start of the control data block
 	static const uint8_t CheckSize  = 8;     // 8 bytes to cover both std and high res
 	static const uint8_t DataOffset = 0x06;  // start of the data we're interested in (7 / 8)
 	uint8_t checkData[CheckSize] = { 0x00 }, verifyData[CheckSize] = { 0x00 };
 	do {
-		if (!requestData(CheckPtr, CheckSize, checkData)) return false;
+		if (!requestControlData(CheckSize, checkData)) return false;
 		delayMicroseconds(I2C_ConversionDelay);  // need a brief delay between reads
-		if (!requestData(CheckPtr, CheckSize, verifyData)) return false;
+		if (!requestControlData(CheckSize, verifyData)) return false;
 
 		boolean equal = true;
 		for (uint8_t i = 0; i < CheckSize - DataOffset; i++) {
@@ -206,7 +205,7 @@ boolean ClassicController_Shared::setDataMode(boolean hr, boolean verify) {
 	if (!writeSuccess) {
 		// we don't care about this data, we just need someplace to dump it
 		uint8_t buffer[MinRequestSize];
-		if (!requestData(0x00, MinRequestSize, buffer)) return false;  // bad read, we must be disconnected
+		if (!requestControlData(MinRequestSize, buffer)) return false;  // bad read, we must be disconnected
 
 		// if we're going to perfom more reads below, the controller needs a short delay to catch its breath
 		if(verify == true) delayMicroseconds(I2C_ConversionDelay);

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -203,8 +203,7 @@ boolean ClassicController_Shared::setDataMode(boolean hr, boolean verify) {
 	 * error.
 	 */
 	if (!writeSuccess) {
-		// we don't care about this data, we just need someplace to dump it
-		uint8_t buffer[MinRequestSize];
+		uint8_t buffer[MinRequestSize];  // we don't care about this data, we just need someplace to dump it
 		if (!requestControlData(MinRequestSize, buffer)) return false;  // bad read, we must be disconnected
 
 		// if we're going to perfom more reads below, the controller needs a short delay to catch its breath
@@ -212,7 +211,7 @@ boolean ClassicController_Shared::setDataMode(boolean hr, boolean verify) {
 	}
 
 	if (verify == true) {
-		boolean currentMode;  // buffer for deduced controller's HR setting 
+		boolean currentMode;  // buffer for controller's deduced HR setting, set in the 'check' function
 		if (!checkDataMode(&currentMode)) return false;  // error: could not read mode
 		highRes = currentMode;  // save current mode to class
 	}

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -189,7 +189,7 @@ boolean ClassicController_Shared::setDataMode(boolean hr, boolean verify) {
 	if (!writeRegister(0xFE, regVal)) return false;  // write to controller
 
 	if (verify == true) {
-		boolean currentMode = false;  // check controller's HR setting 
+		boolean currentMode;  // buffer for deduced controller's HR setting 
 		if (!checkDataMode(&currentMode)) return false;  // error: could not read mode
 		highRes = currentMode;  // save current mode to class
 	}


### PR DESCRIPTION
It appears that some Classic Controller clones designed before the "high resolution" mode was discovered do not properly acknowledge requests sent to the data mode register (`0xFE`). As a result of this those controllers NACK the data mode register write, causing the `ClassicController` `connect()` function to return an error and inform the user that the controller is not connected. Normally the request would only be NACK'd if the controller isn't connected to the bus, so this is seen as a communication error.

This change adds a secondary check after the data mode register write to see if the controller is still connected by polling for control data. If this check returns the requested number of bytes we can assume the controller NACK'd the register write but is still connected to the bus, and we can proceed with the rest of the data mode function. For the example controller reported the data mode check still works as intended, so the class should work with all Classic Controller variations encountered thus far.

This change closes #68.