### PR TITLE
Linked list for multiple types

### DIFF
--- a/examples/Any/IdentifyController/IdentifyController.ino
+++ b/examples/Any/IdentifyController/IdentifyController.ino
@@ -30,10 +30,12 @@ ExtensionPort controller;
 
 void setup() {
 	Serial.begin(115200);
+	while (!Serial);  // wait for connection
+
 	controller.begin();
 	controller.connect();
 
-	ExtensionType conType = controller.getExpectedType();
+	ExtensionType conType = controller.getControllerType();
 
 	switch (conType) {
 		case(ExtensionType::NoController):

--- a/examples/Any/IdentifyController/IdentifyController.ino
+++ b/examples/Any/IdentifyController/IdentifyController.ino
@@ -33,7 +33,7 @@ void setup() {
 	controller.begin();
 	controller.connect();
 
-	ExtensionType conType = controller.getControllerType();
+	ExtensionType conType = controller.getExpectedType();
 
 	switch (conType) {
 		case(ExtensionType::NoController):

--- a/examples/Any/MultipleTypes/MultipleTypes.ino
+++ b/examples/Any/MultipleTypes/MultipleTypes.ino
@@ -45,7 +45,7 @@ void loop() {
 	boolean success = port.update();  // Get new data from the controller
 
 	if (success == true) {  // We've got data!
-		ExtensionType type = port.getConnectedType();
+		ExtensionType type = port.getControllerType();
 
 		switch (type) {
 			case(ExtensionType::Nunchuk):

--- a/keywords.txt
+++ b/keywords.txt
@@ -9,8 +9,8 @@
 # Library
 NintendoExtensionCtrl	KEYWORD1
 
-# Controller Base Classes
-ExtensionController	KEYWORD1
+# Multiple Controller Classes
+ExtensionPort	KEYWORD1
 Shared	KEYWORD1
 
 # Wii Controllers
@@ -19,7 +19,7 @@ ClassicController	KEYWORD1
 GuitarController	KEYWORD1
 DrumController	KEYWORD1
 DJTurntableController	KEYWORD1
-uDrawTablet	 KEYWORD1
+uDrawTablet	KEYWORD1
 DrawsomeTablet	KEYWORD1
 
 # Mini Controllers
@@ -49,6 +49,7 @@ update	KEYWORD2
 
 reset	KEYWORD2
 
+getExpectedType	KEYWORD2
 getControllerType	KEYWORD2
 controllerTypeMatches	KEYWORD2
 

--- a/src/NintendoExtensionCtrl.h
+++ b/src/NintendoExtensionCtrl.h
@@ -20,8 +20,8 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NintendoExtensionCtrl_h
-#define NintendoExtensionCtrl_h
+#ifndef NINTENDOEXTENSIONCTRL_H
+#define NINTENDOEXTENSIONCTRL_H
 
 // Controller Base
 #include "internal/ExtensionController.h"

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -117,6 +117,10 @@ boolean ClassicController_Shared::specificInit() {
 	return setDataMode(true);  // try to set 'high res' mode. 'success' if no comms errors
 }
 
+ExtensionType ClassicController_Shared::getControllerType() const {
+	return ExtensionType::ClassicController;
+}
+
 boolean ClassicController_Shared::checkDataMode(boolean *hr) const {
 	/* Programmator Emptor: vvv This is where all of the headaches stem from vvv */
 

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -117,7 +117,7 @@ boolean ClassicControllerBase::specificInit() {
 	return setDataMode(true);  // try to set 'high res' mode. 'success' if no comms errors
 }
 
-ExtensionType ClassicControllerBase::getControllerType() const {
+ExtensionType ClassicControllerBase::getExpectedType() const {
 	return ExtensionType::ClassicController;
 }
 

--- a/src/controllers/ClassicController.cpp
+++ b/src/controllers/ClassicController.cpp
@@ -25,63 +25,63 @@
 namespace NintendoExtensionCtrl {
 
 // Standard Maps
-constexpr ByteMap ClassicController_Shared::Maps::LeftJoyX;
-constexpr ByteMap ClassicController_Shared::Maps::LeftJoyY;
+constexpr ByteMap ClassicControllerBase::Maps::LeftJoyX;
+constexpr ByteMap ClassicControllerBase::Maps::LeftJoyY;
 
-constexpr ByteMap ClassicController_Shared::Maps::RightJoyX[3];
-constexpr ByteMap ClassicController_Shared::Maps::RightJoyY;
+constexpr ByteMap ClassicControllerBase::Maps::RightJoyX[3];
+constexpr ByteMap ClassicControllerBase::Maps::RightJoyY;
 
-constexpr BitMap  ClassicController_Shared::Maps::DpadUp;
-constexpr BitMap  ClassicController_Shared::Maps::DpadDown;
-constexpr BitMap  ClassicController_Shared::Maps::DpadLeft;
-constexpr BitMap  ClassicController_Shared::Maps::DpadRight;
+constexpr BitMap  ClassicControllerBase::Maps::DpadUp;
+constexpr BitMap  ClassicControllerBase::Maps::DpadDown;
+constexpr BitMap  ClassicControllerBase::Maps::DpadLeft;
+constexpr BitMap  ClassicControllerBase::Maps::DpadRight;
 
-constexpr BitMap  ClassicController_Shared::Maps::ButtonA;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonB;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonX;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonY;
+constexpr BitMap  ClassicControllerBase::Maps::ButtonA;
+constexpr BitMap  ClassicControllerBase::Maps::ButtonB;
+constexpr BitMap  ClassicControllerBase::Maps::ButtonX;
+constexpr BitMap  ClassicControllerBase::Maps::ButtonY;
 
-constexpr ByteMap ClassicController_Shared::Maps::TriggerL[2];
-constexpr ByteMap ClassicController_Shared::Maps::TriggerR;
+constexpr ByteMap ClassicControllerBase::Maps::TriggerL[2];
+constexpr ByteMap ClassicControllerBase::Maps::TriggerR;
 
-constexpr BitMap  ClassicController_Shared::Maps::ButtonL;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonR;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonZL;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonZR;
+constexpr BitMap  ClassicControllerBase::Maps::ButtonL;
+constexpr BitMap  ClassicControllerBase::Maps::ButtonR;
+constexpr BitMap  ClassicControllerBase::Maps::ButtonZL;
+constexpr BitMap  ClassicControllerBase::Maps::ButtonZR;
 
-constexpr BitMap  ClassicController_Shared::Maps::ButtonPlus;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonMinus;
-constexpr BitMap  ClassicController_Shared::Maps::ButtonHome;
+constexpr BitMap  ClassicControllerBase::Maps::ButtonPlus;
+constexpr BitMap  ClassicControllerBase::Maps::ButtonMinus;
+constexpr BitMap  ClassicControllerBase::Maps::ButtonHome;
 
 
 // High Resolution Maps
-constexpr IndexMap ClassicController_Shared::MapsHR::LeftJoyX;
-constexpr IndexMap ClassicController_Shared::MapsHR::LeftJoyY;
+constexpr IndexMap ClassicControllerBase::MapsHR::LeftJoyX;
+constexpr IndexMap ClassicControllerBase::MapsHR::LeftJoyY;
 
-constexpr IndexMap ClassicController_Shared::MapsHR::RightJoyX;
-constexpr IndexMap ClassicController_Shared::MapsHR::RightJoyY;
+constexpr IndexMap ClassicControllerBase::MapsHR::RightJoyX;
+constexpr IndexMap ClassicControllerBase::MapsHR::RightJoyY;
 
-constexpr BitMap   ClassicController_Shared::MapsHR::DpadUp;
-constexpr BitMap   ClassicController_Shared::MapsHR::DpadDown;
-constexpr BitMap   ClassicController_Shared::MapsHR::DpadLeft;
-constexpr BitMap   ClassicController_Shared::MapsHR::DpadRight;
+constexpr BitMap   ClassicControllerBase::MapsHR::DpadUp;
+constexpr BitMap   ClassicControllerBase::MapsHR::DpadDown;
+constexpr BitMap   ClassicControllerBase::MapsHR::DpadLeft;
+constexpr BitMap   ClassicControllerBase::MapsHR::DpadRight;
 
-constexpr BitMap   ClassicController_Shared::MapsHR::ButtonA;
-constexpr BitMap   ClassicController_Shared::MapsHR::ButtonB;
-constexpr BitMap   ClassicController_Shared::MapsHR::ButtonX;
-constexpr BitMap   ClassicController_Shared::MapsHR::ButtonY;
+constexpr BitMap   ClassicControllerBase::MapsHR::ButtonA;
+constexpr BitMap   ClassicControllerBase::MapsHR::ButtonB;
+constexpr BitMap   ClassicControllerBase::MapsHR::ButtonX;
+constexpr BitMap   ClassicControllerBase::MapsHR::ButtonY;
 
-constexpr IndexMap ClassicController_Shared::MapsHR::TriggerL;
-constexpr IndexMap ClassicController_Shared::MapsHR::TriggerR;
+constexpr IndexMap ClassicControllerBase::MapsHR::TriggerL;
+constexpr IndexMap ClassicControllerBase::MapsHR::TriggerR;
 
-constexpr BitMap   ClassicController_Shared::MapsHR::ButtonL;
-constexpr BitMap   ClassicController_Shared::MapsHR::ButtonR;
-constexpr BitMap   ClassicController_Shared::MapsHR::ButtonZL;
-constexpr BitMap   ClassicController_Shared::MapsHR::ButtonZR;
+constexpr BitMap   ClassicControllerBase::MapsHR::ButtonL;
+constexpr BitMap   ClassicControllerBase::MapsHR::ButtonR;
+constexpr BitMap   ClassicControllerBase::MapsHR::ButtonZL;
+constexpr BitMap   ClassicControllerBase::MapsHR::ButtonZR;
 
-constexpr BitMap   ClassicController_Shared::MapsHR::ButtonPlus;
-constexpr BitMap   ClassicController_Shared::MapsHR::ButtonMinus;
-constexpr BitMap   ClassicController_Shared::MapsHR::ButtonHome;
+constexpr BitMap   ClassicControllerBase::MapsHR::ButtonPlus;
+constexpr BitMap   ClassicControllerBase::MapsHR::ButtonMinus;
+constexpr BitMap   ClassicControllerBase::MapsHR::ButtonHome;
 
 
 /* Making use of the preprocessor here to repeat these conditionals for every
@@ -101,7 +101,7 @@ constexpr BitMap   ClassicController_Shared::MapsHR::ButtonHome;
 #define HRBIT(map)  !highRes ? getControlBit(Maps::map) : getControlBit(MapsHR::map)
 
 
-boolean ClassicController_Shared::specificInit() {
+boolean ClassicControllerBase::specificInit() {
 	/* On init, try to set the controller to work in "high resolution" mode so
 	 * we get a full byte of data for each analog input. Then read the current
 	 * "data mode" from the controller so that the control surface functions
@@ -117,11 +117,11 @@ boolean ClassicController_Shared::specificInit() {
 	return setDataMode(true);  // try to set 'high res' mode. 'success' if no comms errors
 }
 
-ExtensionType ClassicController_Shared::getControllerType() const {
+ExtensionType ClassicControllerBase::getControllerType() const {
 	return ExtensionType::ClassicController;
 }
 
-boolean ClassicController_Shared::checkDataMode(boolean *hr) const {
+boolean ClassicControllerBase::checkDataMode(boolean *hr) const {
 	/* Programmator Emptor: vvv This is where all of the headaches stem from vvv */
 
 	/* Okay, so here's the deal. The Wii Classic Controller reports its data
@@ -187,7 +187,7 @@ boolean ClassicController_Shared::checkDataMode(boolean *hr) const {
 	return true;  // successfully read state
 }
 
-boolean ClassicController_Shared::setDataMode(boolean hr, boolean verify) {
+boolean ClassicControllerBase::setDataMode(boolean hr, boolean verify) {
 	const uint8_t regVal = hr ? 0x03 : 0x01;  // 0x03 for high res, 0x01 for standard
 
 	// Attempt to write 'high res' mode to controller register.
@@ -233,108 +233,108 @@ boolean ClassicController_Shared::setDataMode(boolean hr, boolean verify) {
 	return true;  // 'success' if no communication errors, regardless of setting
 }
 
-boolean ClassicController_Shared::setHighRes(boolean hr, boolean verify) {
+boolean ClassicControllerBase::setHighRes(boolean hr, boolean verify) {
 	// 'success' if the mode is changed to the one we're trying to set
 	return setDataMode(hr, verify) && (getHighRes() == hr);
 }
 
-boolean ClassicController_Shared::getHighRes() const {
+boolean ClassicControllerBase::getHighRes() const {
 	return highRes;
 }
 
-uint8_t ClassicController_Shared::leftJoyX() const {
+uint8_t ClassicControllerBase::leftJoyX() const {
 	return HRDATA(LeftJoyX, 2);  // 6 bits for standard range, so shift left (8-6)
 }
 
-uint8_t ClassicController_Shared::leftJoyY() const {
+uint8_t ClassicControllerBase::leftJoyY() const {
 	return HRDATA(LeftJoyY, 2);
 }
 
-uint8_t ClassicController_Shared::rightJoyX() const {
+uint8_t ClassicControllerBase::rightJoyX() const {
 	return HRDATA(RightJoyX, 3);  // 5 bits for standard range, so shift left (8-5)
 }
 
-uint8_t ClassicController_Shared::rightJoyY() const {
+uint8_t ClassicControllerBase::rightJoyY() const {
 	return HRDATA(RightJoyY, 3);
 }
 
-boolean ClassicController_Shared::dpadUp() const {
+boolean ClassicControllerBase::dpadUp() const {
 	return HRBIT(DpadUp);
 }
 
-boolean ClassicController_Shared::dpadDown() const {
+boolean ClassicControllerBase::dpadDown() const {
 	return HRBIT(DpadDown);
 }
 
-boolean ClassicController_Shared::dpadLeft() const {
+boolean ClassicControllerBase::dpadLeft() const {
 	return HRBIT(DpadLeft);
 }
 
-boolean ClassicController_Shared::dpadRight() const {
+boolean ClassicControllerBase::dpadRight() const {
 	return HRBIT(DpadRight);
 }
 
-boolean ClassicController_Shared::buttonA() const {
+boolean ClassicControllerBase::buttonA() const {
 	return HRBIT(ButtonA);
 }
 
-boolean ClassicController_Shared::buttonB() const {
+boolean ClassicControllerBase::buttonB() const {
 	return HRBIT(ButtonB);
 }
 
-boolean ClassicController_Shared::buttonX() const {
+boolean ClassicControllerBase::buttonX() const {
 	return HRBIT(ButtonX);
 }
 
-boolean ClassicController_Shared::buttonY() const {
+boolean ClassicControllerBase::buttonY() const {
 	return HRBIT(ButtonY);
 }
 
-uint8_t ClassicController_Shared::triggerL() const {
+uint8_t ClassicControllerBase::triggerL() const {
 	return HRDATA(TriggerL, 3);  // 5 bits for standard range, so shift left (8-5)
 }
 
-uint8_t ClassicController_Shared::triggerR() const {
+uint8_t ClassicControllerBase::triggerR() const {
 	return HRDATA(TriggerR, 3);
 }
 
-boolean ClassicController_Shared::buttonL() const {
+boolean ClassicControllerBase::buttonL() const {
 	return HRBIT(ButtonL);
 }
 
-boolean ClassicController_Shared::buttonR() const {
+boolean ClassicControllerBase::buttonR() const {
 	return HRBIT(ButtonR);
 }
 
-boolean ClassicController_Shared::buttonZL() const {
+boolean ClassicControllerBase::buttonZL() const {
 	return HRBIT(ButtonZL);
 }
 
-boolean ClassicController_Shared::buttonZR() const {
+boolean ClassicControllerBase::buttonZR() const {
 	return HRBIT(ButtonZR);
 }
 
-boolean ClassicController_Shared::buttonStart() const {
+boolean ClassicControllerBase::buttonStart() const {
 	return buttonPlus();
 }
 
-boolean ClassicController_Shared::buttonSelect() const {
+boolean ClassicControllerBase::buttonSelect() const {
 	return buttonMinus();
 }
 
-boolean ClassicController_Shared::buttonPlus() const {
+boolean ClassicControllerBase::buttonPlus() const {
 	return HRBIT(ButtonPlus);
 }
 
-boolean ClassicController_Shared::buttonMinus() const {
+boolean ClassicControllerBase::buttonMinus() const {
 	return HRBIT(ButtonMinus);
 }
 
-boolean ClassicController_Shared::buttonHome() const {
+boolean ClassicControllerBase::buttonHome() const {
 	return HRBIT(ButtonHome);
 }
 
-void ClassicController_Shared::printDebug(Print& output) const {
+void ClassicControllerBase::printDebug(Print& output) const {
 	const char fillCharacter = '_';
 
 	char buffer[68];
@@ -379,7 +379,7 @@ void ClassicController_Shared::printDebug(Print& output) const {
 
 // ######### Mini Controller Support #########
 
-void NESMiniController_Shared::printDebug(Print& output) const {
+void NESMiniControllerBase::printDebug(Print& output) const {
 	const char fillCharacter = '_';
 
 	output.print("NES ");
@@ -402,7 +402,7 @@ void NESMiniController_Shared::printDebug(Print& output) const {
 	output.println();
 }
 
-void SNESMiniController_Shared::printDebug(Print& output) const {
+void SNESMiniControllerBase::printDebug(Print& output) const {
 	const char fillCharacter = '_';
 
 	output.print("SNES ");

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -20,8 +20,8 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NXC_ClassicController_h
-#define NXC_ClassicController_h
+#ifndef NXC_CLASSICCONTROLLER_H
+#define NXC_CLASSICCONTROLLER_H
 
 #include "internal/ExtensionController.h"
 

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -26,7 +26,7 @@
 #include "internal/ExtensionController.h"
 
 namespace NintendoExtensionCtrl {
-	class ClassicController_Shared : public ExtensionController {
+	class ClassicControllerBase : public ExtensionController {
 	public:
 		struct Maps {
 			/* Classic Controller "Standard" Mode
@@ -108,11 +108,11 @@ namespace NintendoExtensionCtrl {
 			constexpr static BitMap   ButtonHome = { 6, 3 };
 		};
 
-		ClassicController_Shared(ExtensionData &dataRef) :
+		ClassicControllerBase(ExtensionData &dataRef) :
 			ExtensionController(dataRef) {}
 
-		ClassicController_Shared(ExtensionPort &port) :
-			ClassicController_Shared(port.getExtensionData()) {}
+		ClassicControllerBase(ExtensionPort &port) :
+			ClassicControllerBase(port.getExtensionData()) {}
 
 		boolean specificInit();
 
@@ -166,28 +166,28 @@ namespace NintendoExtensionCtrl {
 
 	/* Nintendo Mini Console Controllers */
 
-	class NESMiniController_Shared : public ClassicController_Shared {
+	class NESMiniControllerBase : public ClassicControllerBase {
 	public:
-		using ClassicController_Shared::ClassicController_Shared;
+		using ClassicControllerBase::ClassicControllerBase;
 
 		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 	};
 
-	class SNESMiniController_Shared : public ClassicController_Shared {
+	class SNESMiniControllerBase : public ClassicControllerBase {
 	public:
-		using ClassicController_Shared::ClassicController_Shared;
+		using ClassicControllerBase::ClassicControllerBase;
 
 		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
 	};
 }
 
 using ClassicController = NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::ClassicController_Shared>;
+	<NintendoExtensionCtrl::ClassicControllerBase>;
 
 using NESMiniController = NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::NESMiniController_Shared>;
+	<NintendoExtensionCtrl::NESMiniControllerBase>;
 
 using SNESMiniController = NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::SNESMiniController_Shared>;
+	<NintendoExtensionCtrl::SNESMiniControllerBase>;
 
 #endif

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -111,9 +111,6 @@ namespace NintendoExtensionCtrl {
 		ClassicControllerBase(ExtensionData &dataRef) :
 			ExtensionController(dataRef) {}
 
-		ClassicControllerBase(ExtensionPort &port) :
-			ClassicControllerBase(port.getExtensionData()) {}
-
 		boolean specificInit();
 
 		ExtensionType getControllerType() const;

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -108,8 +108,7 @@ namespace NintendoExtensionCtrl {
 			constexpr static BitMap   ButtonHome = { 6, 3 };
 		};
 
-		ClassicControllerBase(ExtensionData &dataRef) :
-			ExtensionController(dataRef) {}
+		using ExtensionController::ExtensionController;
 
 		boolean specificInit();
 

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -112,7 +112,7 @@ namespace NintendoExtensionCtrl {
 
 		boolean specificInit();
 
-		ExtensionType getControllerType() const;
+		ExtensionType getExpectedType() const;
 
 		boolean setHighRes(boolean hr = true, boolean verify = true);
 		boolean getHighRes() const;

--- a/src/controllers/ClassicController.h
+++ b/src/controllers/ClassicController.h
@@ -109,12 +109,14 @@ namespace NintendoExtensionCtrl {
 		};
 
 		ClassicController_Shared(ExtensionData &dataRef) :
-			ExtensionController(dataRef, ExtensionType::ClassicController) {}
+			ExtensionController(dataRef) {}
 
 		ClassicController_Shared(ExtensionPort &port) :
 			ClassicController_Shared(port.getExtensionData()) {}
 
 		boolean specificInit();
+
+		ExtensionType getControllerType() const;
 
 		boolean setHighRes(boolean hr = true, boolean verify = true);
 		boolean getHighRes() const;

--- a/src/controllers/DJTurntable.cpp
+++ b/src/controllers/DJTurntable.cpp
@@ -47,6 +47,10 @@ constexpr ByteMap DJTurntableController_Shared::Maps::CrossfadeSlider;
 
 constexpr BitMap  DJTurntableController_Shared::Maps::ButtonEuphoria;
 
+ExtensionType DJTurntableController_Shared::getControllerType() const {
+	return ExtensionType::DJTurntableController;
+}
+
 // Combined Turntable
 int8_t DJTurntableController_Shared::turntable() const {
 	return left.turntable() + right.turntable();

--- a/src/controllers/DJTurntable.cpp
+++ b/src/controllers/DJTurntable.cpp
@@ -47,7 +47,7 @@ constexpr ByteMap DJTurntableControllerBase::Maps::CrossfadeSlider;
 
 constexpr BitMap  DJTurntableControllerBase::Maps::ButtonEuphoria;
 
-ExtensionType DJTurntableControllerBase::getControllerType() const {
+ExtensionType DJTurntableControllerBase::getExpectedType() const {
 	return ExtensionType::DJTurntableController;
 }
 

--- a/src/controllers/DJTurntable.cpp
+++ b/src/controllers/DJTurntable.cpp
@@ -24,80 +24,80 @@
 
 namespace NintendoExtensionCtrl {
 
-constexpr ByteMap DJTurntableController_Shared::Maps::JoyX;
-constexpr ByteMap DJTurntableController_Shared::Maps::JoyY;
+constexpr ByteMap DJTurntableControllerBase::Maps::JoyX;
+constexpr ByteMap DJTurntableControllerBase::Maps::JoyY;
 
-constexpr BitMap  DJTurntableController_Shared::Maps::ButtonPlus;
-constexpr BitMap  DJTurntableController_Shared::Maps::ButtonMinus;
+constexpr BitMap  DJTurntableControllerBase::Maps::ButtonPlus;
+constexpr BitMap  DJTurntableControllerBase::Maps::ButtonMinus;
 
-constexpr ByteMap DJTurntableController_Shared::Maps::Left_Turntable;
-constexpr ByteMap DJTurntableController_Shared::Maps::Left_TurntableSign;
-constexpr BitMap  DJTurntableController_Shared::Maps::Left_ButtonGreen;
-constexpr BitMap  DJTurntableController_Shared::Maps::Left_ButtonRed;
-constexpr BitMap  DJTurntableController_Shared::Maps::Left_ButtonBlue;
+constexpr ByteMap DJTurntableControllerBase::Maps::Left_Turntable;
+constexpr ByteMap DJTurntableControllerBase::Maps::Left_TurntableSign;
+constexpr BitMap  DJTurntableControllerBase::Maps::Left_ButtonGreen;
+constexpr BitMap  DJTurntableControllerBase::Maps::Left_ButtonRed;
+constexpr BitMap  DJTurntableControllerBase::Maps::Left_ButtonBlue;
 
-constexpr ByteMap DJTurntableController_Shared::Maps::Right_Turntable[3];
-constexpr ByteMap DJTurntableController_Shared::Maps::Right_TurntableSign;
-constexpr BitMap  DJTurntableController_Shared::Maps::Right_ButtonGreen;
-constexpr BitMap  DJTurntableController_Shared::Maps::Right_ButtonRed;
-constexpr BitMap  DJTurntableController_Shared::Maps::Right_ButtonBlue;
+constexpr ByteMap DJTurntableControllerBase::Maps::Right_Turntable[3];
+constexpr ByteMap DJTurntableControllerBase::Maps::Right_TurntableSign;
+constexpr BitMap  DJTurntableControllerBase::Maps::Right_ButtonGreen;
+constexpr BitMap  DJTurntableControllerBase::Maps::Right_ButtonRed;
+constexpr BitMap  DJTurntableControllerBase::Maps::Right_ButtonBlue;
 
-constexpr ByteMap DJTurntableController_Shared::Maps::EffectDial[2];
-constexpr ByteMap DJTurntableController_Shared::Maps::CrossfadeSlider;
+constexpr ByteMap DJTurntableControllerBase::Maps::EffectDial[2];
+constexpr ByteMap DJTurntableControllerBase::Maps::CrossfadeSlider;
 
-constexpr BitMap  DJTurntableController_Shared::Maps::ButtonEuphoria;
+constexpr BitMap  DJTurntableControllerBase::Maps::ButtonEuphoria;
 
-ExtensionType DJTurntableController_Shared::getControllerType() const {
+ExtensionType DJTurntableControllerBase::getControllerType() const {
 	return ExtensionType::DJTurntableController;
 }
 
 // Combined Turntable
-int8_t DJTurntableController_Shared::turntable() const {
+int8_t DJTurntableControllerBase::turntable() const {
 	return left.turntable() + right.turntable();
 }
 
-boolean DJTurntableController_Shared::buttonGreen() const {
+boolean DJTurntableControllerBase::buttonGreen() const {
 	return left.buttonGreen() | right.buttonGreen();
 }
 
-boolean DJTurntableController_Shared::buttonRed() const {
+boolean DJTurntableControllerBase::buttonRed() const {
 	return left.buttonRed() | right.buttonRed();
 }
 
-boolean DJTurntableController_Shared::buttonBlue() const {
+boolean DJTurntableControllerBase::buttonBlue() const {
 	return left.buttonBlue() | right.buttonBlue();
 }
 
 // Main Board
-uint8_t DJTurntableController_Shared::effectDial() const {
+uint8_t DJTurntableControllerBase::effectDial() const {
 	return getControlData(Maps::EffectDial);
 }
 
-uint8_t DJTurntableController_Shared::crossfadeSlider() const {
+uint8_t DJTurntableControllerBase::crossfadeSlider() const {
 	return getControlData(Maps::CrossfadeSlider);
 }
 
-boolean DJTurntableController_Shared::buttonEuphoria() const {
+boolean DJTurntableControllerBase::buttonEuphoria() const {
 	return getControlBit(Maps::ButtonEuphoria);
 }
 
-uint8_t DJTurntableController_Shared::joyX() const {
+uint8_t DJTurntableControllerBase::joyX() const {
 	return getControlData(Maps::JoyX);
 }
 
-uint8_t DJTurntableController_Shared::joyY() const {
+uint8_t DJTurntableControllerBase::joyY() const {
 	return getControlData(Maps::JoyY);
 }
 
-boolean DJTurntableController_Shared::buttonPlus() const {
+boolean DJTurntableControllerBase::buttonPlus() const {
 	return getControlBit(Maps::ButtonPlus);
 }
 
-boolean DJTurntableController_Shared::buttonMinus() const {
+boolean DJTurntableControllerBase::buttonMinus() const {
 	return getControlBit(Maps::ButtonMinus);
 }
 
-DJTurntableController_Shared::TurntableConfig DJTurntableController_Shared::getTurntableConfig() {
+DJTurntableControllerBase::TurntableConfig DJTurntableControllerBase::getTurntableConfig() {
 	if (tableConfig == TurntableConfig::Both) {
 		return tableConfig;  // Both are attached, no reason to check data
 	}
@@ -119,7 +119,7 @@ DJTurntableController_Shared::TurntableConfig DJTurntableController_Shared::getT
 	}
 }
 
-uint8_t DJTurntableController_Shared::getNumTurntables() {
+uint8_t DJTurntableControllerBase::getNumTurntables() {
 	getTurntableConfig();  // Update config from data
 
 	switch (tableConfig) {
@@ -137,7 +137,7 @@ uint8_t DJTurntableController_Shared::getNumTurntables() {
 	return 0;  // Just in-case
 }
 
-void DJTurntableController_Shared::printDebug(Print& output) {
+void DJTurntableControllerBase::printDebug(Print& output) {
 	const char fillCharacter = '_';
 
 	char buffer[45];
@@ -172,7 +172,7 @@ void DJTurntableController_Shared::printDebug(Print& output) {
 	output.println();
 }
 
-void DJTurntableController_Shared::printTurntable(Print& output, TurntableExpansion &table) const {
+void DJTurntableControllerBase::printTurntable(Print& output, TurntableExpansion &table) const {
 	const char fillCharacter = '_';
 
 	char idPrint = 'X';
@@ -197,7 +197,7 @@ void DJTurntableController_Shared::printTurntable(Print& output, TurntableExpans
 }
 
 // Turntable Expansion Base
-boolean DJTurntableController_Shared::TurntableExpansion::connected() const {
+boolean DJTurntableControllerBase::TurntableExpansion::connected() const {
 	if (base.tableConfig == TurntableConfig::Both || base.tableConfig == side) {
 		return true;  // Already checked
 	}
@@ -205,45 +205,45 @@ boolean DJTurntableController_Shared::TurntableExpansion::connected() const {
 }
 
 // Left Turntable
-int8_t DJTurntableController_Shared::TurntableLeft::turntable() const {
+int8_t DJTurntableControllerBase::TurntableLeft::turntable() const {
 	uint8_t turnData = base.getControlData(Maps::Left_Turntable);
 	boolean turnSign = base.getControlData(Maps::Left_TurntableSign);
 	return getTurntableSpeed(turnData, turnSign);
 }
 
-boolean DJTurntableController_Shared::TurntableLeft::buttonGreen() const {
+boolean DJTurntableControllerBase::TurntableLeft::buttonGreen() const {
 	return base.getControlBit(Maps::Left_ButtonGreen);
 }
 
-boolean DJTurntableController_Shared::TurntableLeft::buttonRed() const {
+boolean DJTurntableControllerBase::TurntableLeft::buttonRed() const {
 	return base.getControlBit(Maps::Left_ButtonRed);
 }
 
-boolean DJTurntableController_Shared::TurntableLeft::buttonBlue() const {
+boolean DJTurntableControllerBase::TurntableLeft::buttonBlue() const {
 	return base.getControlBit(Maps::Left_ButtonBlue);
 }
 
 // Right Turntable
-int8_t DJTurntableController_Shared::TurntableRight::turntable() const {
+int8_t DJTurntableControllerBase::TurntableRight::turntable() const {
 	uint8_t turnData = base.getControlData(Maps::Right_Turntable);
 	boolean turnSign = base.getControlData(Maps::Right_TurntableSign);
 	return getTurntableSpeed(turnData, turnSign);
 }
 
-boolean DJTurntableController_Shared::TurntableRight::buttonGreen() const {
+boolean DJTurntableControllerBase::TurntableRight::buttonGreen() const {
 	return base.getControlBit(Maps::Right_ButtonGreen);
 }
 
-boolean DJTurntableController_Shared::TurntableRight::buttonRed() const {
+boolean DJTurntableControllerBase::TurntableRight::buttonRed() const {
 	return base.getControlBit(Maps::Right_ButtonRed);
 }
 
-boolean DJTurntableController_Shared::TurntableRight::buttonBlue() const {
+boolean DJTurntableControllerBase::TurntableRight::buttonBlue() const {
 	return base.getControlBit(Maps::Right_ButtonBlue);
 }
 
 // Effect Rollover
-int8_t DJTurntableController_Shared::EffectRollover::getChange() {
+int8_t DJTurntableControllerBase::EffectRollover::getChange() {
 	return RolloverChange::getChange(dj.effectDial());
 }
 

--- a/src/controllers/DJTurntable.h
+++ b/src/controllers/DJTurntable.h
@@ -56,10 +56,12 @@ namespace NintendoExtensionCtrl {
 		};
 
 		DJTurntableController_Shared(ExtensionData& dataRef) : 
-			ExtensionController(dataRef, ExtensionType::DJTurntableController), left(*this), right(*this) {}
+			ExtensionController(dataRef), left(*this), right(*this) {}
 
 		DJTurntableController_Shared(ExtensionPort &port) :
 			DJTurntableController_Shared(port.getExtensionData()) {}
+
+		ExtensionType getControllerType() const;
 
 		enum class TurntableConfig {
 			BaseOnly,

--- a/src/controllers/DJTurntable.h
+++ b/src/controllers/DJTurntable.h
@@ -28,14 +28,14 @@
 #include "ClassicController.h"  // For joystick and +/- control maps
 
 namespace NintendoExtensionCtrl {
-	class DJTurntableController_Shared : public ExtensionController {
+	class DJTurntableControllerBase : public ExtensionController {
 	public:
 		struct Maps {
-			constexpr static ByteMap JoyX = ClassicController_Shared::Maps::LeftJoyX;
-			constexpr static ByteMap JoyY = ClassicController_Shared::Maps::LeftJoyY;
+			constexpr static ByteMap JoyX = ClassicControllerBase::Maps::LeftJoyX;
+			constexpr static ByteMap JoyY = ClassicControllerBase::Maps::LeftJoyY;
 
-			constexpr static BitMap  ButtonPlus = ClassicController_Shared::Maps::ButtonPlus;
-			constexpr static BitMap  ButtonMinus = ClassicController_Shared::Maps::ButtonMinus;
+			constexpr static BitMap  ButtonPlus = ClassicControllerBase::Maps::ButtonPlus;
+			constexpr static BitMap  ButtonMinus = ClassicControllerBase::Maps::ButtonMinus;
 
 			constexpr static ByteMap Left_Turntable = ByteMap(3, 5, 0, 0);
 			constexpr static ByteMap Left_TurntableSign = ByteMap(4, 1, 0, 0);
@@ -55,11 +55,11 @@ namespace NintendoExtensionCtrl {
 			constexpr static BitMap  ButtonEuphoria = { 5, 4 };
 		};
 
-		DJTurntableController_Shared(ExtensionData& dataRef) : 
+		DJTurntableControllerBase(ExtensionData& dataRef) : 
 			ExtensionController(dataRef), left(*this), right(*this) {}
 
-		DJTurntableController_Shared(ExtensionPort &port) :
-			DJTurntableController_Shared(port.getExtensionData()) {}
+		DJTurntableControllerBase(ExtensionPort &port) :
+			DJTurntableControllerBase(port.getExtensionData()) {}
 
 		ExtensionType getControllerType() const;
 
@@ -94,7 +94,7 @@ namespace NintendoExtensionCtrl {
 
 		class TurntableExpansion {
 		public:
-			TurntableExpansion(TurntableConfig conf, DJTurntableController_Shared &baseObj)
+			TurntableExpansion(TurntableConfig conf, DJTurntableControllerBase &baseObj)
 				: side(conf), base(baseObj) {}
 			boolean connected() const;
 
@@ -113,12 +113,12 @@ namespace NintendoExtensionCtrl {
 				return (int8_t) turnData;
 			}
 
-			const DJTurntableController_Shared & base;
+			const DJTurntableControllerBase & base;
 		};
 
 		class TurntableLeft : public TurntableExpansion {
 		public:
-			TurntableLeft(DJTurntableController_Shared &baseObj)
+			TurntableLeft(DJTurntableControllerBase &baseObj)
 				: TurntableExpansion(TurntableConfig::Left, baseObj) {}
 			int8_t turntable() const;
 
@@ -129,7 +129,7 @@ namespace NintendoExtensionCtrl {
 
 		class TurntableRight : public TurntableExpansion {
 		public:
-			TurntableRight(DJTurntableController_Shared &baseObj)
+			TurntableRight(DJTurntableControllerBase &baseObj)
 				: TurntableExpansion(TurntableConfig::Right, baseObj) {}
 			int8_t turntable() const;
 
@@ -140,10 +140,10 @@ namespace NintendoExtensionCtrl {
 
 		class EffectRollover : private NintendoExtensionCtrl::RolloverChange {
 		public:
-			EffectRollover(DJTurntableController_Shared & controller) : RolloverChange(0, 31), dj(controller) {}
+			EffectRollover(DJTurntableControllerBase & controller) : RolloverChange(0, 31), dj(controller) {}
 			int8_t getChange();
 		private:
-			const DJTurntableController_Shared & dj;
+			const DJTurntableControllerBase & dj;
 		};
 
 	private:
@@ -154,6 +154,6 @@ namespace NintendoExtensionCtrl {
 }
 
 using DJTurntableController = NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::DJTurntableController_Shared>;
+	<NintendoExtensionCtrl::DJTurntableControllerBase>;
 
 #endif

--- a/src/controllers/DJTurntable.h
+++ b/src/controllers/DJTurntable.h
@@ -58,9 +58,6 @@ namespace NintendoExtensionCtrl {
 		DJTurntableControllerBase(ExtensionData& dataRef) : 
 			ExtensionController(dataRef), left(*this), right(*this) {}
 
-		DJTurntableControllerBase(ExtensionPort &port) :
-			DJTurntableControllerBase(port.getExtensionData()) {}
-
 		ExtensionType getControllerType() const;
 
 		enum class TurntableConfig {

--- a/src/controllers/DJTurntable.h
+++ b/src/controllers/DJTurntable.h
@@ -20,8 +20,8 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NXC_DJTurntable_h
-#define NXC_DJTurntable_h
+#ifndef NXC_DJTURNTABLE_H
+#define NXC_DJTURNTABLE_H
 
 #include "internal/ExtensionController.h"
 

--- a/src/controllers/DJTurntable.h
+++ b/src/controllers/DJTurntable.h
@@ -58,7 +58,7 @@ namespace NintendoExtensionCtrl {
 		DJTurntableControllerBase(ExtensionData& dataRef) : 
 			ExtensionController(dataRef), left(*this), right(*this) {}
 
-		ExtensionType getControllerType() const;
+		ExtensionType getExpectedType() const;
 
 		enum class TurntableConfig {
 			BaseOnly,

--- a/src/controllers/DrawsomeTablet.cpp
+++ b/src/controllers/DrawsomeTablet.cpp
@@ -24,17 +24,17 @@
 
 namespace NintendoExtensionCtrl {
 
-constexpr IndexMap  DrawsomeTablet_Shared::Maps::PenX_LSB;
-constexpr IndexMap  DrawsomeTablet_Shared::Maps::PenX_MSB;
-constexpr IndexMap  DrawsomeTablet_Shared::Maps::PenY_LSB;
-constexpr IndexMap  DrawsomeTablet_Shared::Maps::PenY_MSB;
+constexpr IndexMap  DrawsomeTabletBase::Maps::PenX_LSB;
+constexpr IndexMap  DrawsomeTabletBase::Maps::PenX_MSB;
+constexpr IndexMap  DrawsomeTabletBase::Maps::PenY_LSB;
+constexpr IndexMap  DrawsomeTabletBase::Maps::PenY_MSB;
 
-constexpr IndexMap  DrawsomeTablet_Shared::Maps::Pressure_LSB;
-constexpr ByteMap   DrawsomeTablet_Shared::Maps::Pressure_MSB;
+constexpr IndexMap  DrawsomeTabletBase::Maps::Pressure_LSB;
+constexpr ByteMap   DrawsomeTabletBase::Maps::Pressure_MSB;
 
-constexpr BitMap    DrawsomeTablet_Shared::Maps::Pen_Detected;
+constexpr BitMap    DrawsomeTabletBase::Maps::Pen_Detected;
 
-boolean DrawsomeTablet_Shared::specificInit() {
+boolean DrawsomeTabletBase::specificInit() {
 	/* Two necessary register writes during initialization before the tablet
 	 * will start sending data. See this for reference:
 	 * https://www.raphnet.net/divers/wii_graphics_tablets/index_en.php
@@ -42,27 +42,27 @@ boolean DrawsomeTablet_Shared::specificInit() {
 	return writeRegister(0xFB, 0x01) && writeRegister(0xF0, 0x55);
 }
 
-ExtensionType DrawsomeTablet_Shared::getControllerType() const {
+ExtensionType DrawsomeTabletBase::getControllerType() const {
 	return ExtensionType::DrawsomeTablet;
 }
 
-uint16_t DrawsomeTablet_Shared::penX() const {
+uint16_t DrawsomeTabletBase::penX() const {
 	return (getControlData(Maps::PenX_MSB) << 8) | getControlData(Maps::PenX_LSB);
 }
 
-uint16_t DrawsomeTablet_Shared::penY() const {
+uint16_t DrawsomeTabletBase::penY() const {
 	return (getControlData(Maps::PenY_MSB) << 8) | getControlData(Maps::PenY_LSB);
 }
 
-uint16_t DrawsomeTablet_Shared::penPressure() const {
+uint16_t DrawsomeTabletBase::penPressure() const {
 	return (getControlData(Maps::Pressure_MSB) << 8) | getControlData(Maps::Pressure_LSB);
 }
 
-boolean DrawsomeTablet_Shared::penDetected() const {
+boolean DrawsomeTabletBase::penDetected() const {
 	return getControlBit(Maps::Pen_Detected);
 }
 
-void DrawsomeTablet_Shared::printDebug(Print& output) const {
+void DrawsomeTabletBase::printDebug(Print& output) const {
 	char buffer[60];
 	
 	char penPrint = penDetected() ? 'Y' : 'N';

--- a/src/controllers/DrawsomeTablet.cpp
+++ b/src/controllers/DrawsomeTablet.cpp
@@ -42,6 +42,10 @@ boolean DrawsomeTablet_Shared::specificInit() {
 	return writeRegister(0xFB, 0x01) && writeRegister(0xF0, 0x55);
 }
 
+ExtensionType DrawsomeTablet_Shared::getControllerType() const {
+	return ExtensionType::DrawsomeTablet;
+}
+
 uint16_t DrawsomeTablet_Shared::penX() const {
 	return (getControlData(Maps::PenX_MSB) << 8) | getControlData(Maps::PenX_LSB);
 }

--- a/src/controllers/DrawsomeTablet.cpp
+++ b/src/controllers/DrawsomeTablet.cpp
@@ -42,7 +42,7 @@ boolean DrawsomeTabletBase::specificInit() {
 	return writeRegister(0xFB, 0x01) && writeRegister(0xF0, 0x55);
 }
 
-ExtensionType DrawsomeTabletBase::getControllerType() const {
+ExtensionType DrawsomeTabletBase::getExpectedType() const {
 	return ExtensionType::DrawsomeTablet;
 }
 

--- a/src/controllers/DrawsomeTablet.h
+++ b/src/controllers/DrawsomeTablet.h
@@ -45,7 +45,7 @@ namespace NintendoExtensionCtrl {
 
 		boolean specificInit();  // for required register writes at init
 
-		ExtensionType getControllerType() const;
+		ExtensionType getExpectedType() const;
 
 		uint16_t penX() const;  // 16 bits, 0-65535
 		uint16_t penY() const;

--- a/src/controllers/DrawsomeTablet.h
+++ b/src/controllers/DrawsomeTablet.h
@@ -44,9 +44,6 @@ namespace NintendoExtensionCtrl {
 		DrawsomeTabletBase(ExtensionData &dataRef) :
 			ExtensionController(dataRef) {}
 
-		DrawsomeTabletBase(ExtensionPort &port) :
-			DrawsomeTabletBase(port.getExtensionData()) {}
-
 		boolean specificInit();  // for required register writes at init
 
 		ExtensionType getControllerType() const;

--- a/src/controllers/DrawsomeTablet.h
+++ b/src/controllers/DrawsomeTablet.h
@@ -41,8 +41,7 @@ namespace NintendoExtensionCtrl {
 			constexpr static BitMap   Pen_Detected = {5, 7};
 		};
 		
-		DrawsomeTabletBase(ExtensionData &dataRef) :
-			ExtensionController(dataRef) {}
+		using ExtensionController::ExtensionController;
 
 		boolean specificInit();  // for required register writes at init
 

--- a/src/controllers/DrawsomeTablet.h
+++ b/src/controllers/DrawsomeTablet.h
@@ -42,12 +42,14 @@ namespace NintendoExtensionCtrl {
 		};
 		
 		DrawsomeTablet_Shared(ExtensionData &dataRef) :
-			ExtensionController(dataRef, ExtensionType::DrawsomeTablet) {}
+			ExtensionController(dataRef) {}
 
 		DrawsomeTablet_Shared(ExtensionPort &port) :
 			DrawsomeTablet_Shared(port.getExtensionData()) {}
 
 		boolean specificInit();  // for required register writes at init
+
+		ExtensionType getControllerType() const;
 
 		uint16_t penX() const;  // 16 bits, 0-65535
 		uint16_t penY() const;

--- a/src/controllers/DrawsomeTablet.h
+++ b/src/controllers/DrawsomeTablet.h
@@ -26,7 +26,7 @@
 #include "internal/ExtensionController.h"
 
 namespace NintendoExtensionCtrl {
-	class DrawsomeTablet_Shared : public ExtensionController {
+	class DrawsomeTabletBase : public ExtensionController {
 	public:
 		struct Maps {
 			constexpr static IndexMap PenX_LSB = 0;
@@ -41,11 +41,11 @@ namespace NintendoExtensionCtrl {
 			constexpr static BitMap   Pen_Detected = {5, 7};
 		};
 		
-		DrawsomeTablet_Shared(ExtensionData &dataRef) :
+		DrawsomeTabletBase(ExtensionData &dataRef) :
 			ExtensionController(dataRef) {}
 
-		DrawsomeTablet_Shared(ExtensionPort &port) :
-			DrawsomeTablet_Shared(port.getExtensionData()) {}
+		DrawsomeTabletBase(ExtensionPort &port) :
+			DrawsomeTabletBase(port.getExtensionData()) {}
 
 		boolean specificInit();  // for required register writes at init
 
@@ -63,6 +63,6 @@ namespace NintendoExtensionCtrl {
 }
 
 using DrawsomeTablet = NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::DrawsomeTablet_Shared>;
+	<NintendoExtensionCtrl::DrawsomeTabletBase>;
 
 #endif

--- a/src/controllers/DrawsomeTablet.h
+++ b/src/controllers/DrawsomeTablet.h
@@ -20,8 +20,8 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NXC_DrawsomeTablet_h
-#define NXC_DrawsomeTablet_h
+#ifndef NXC_DRAWSOMETABLET_H
+#define NXC_DRAWSOMETABLET_H
 
 #include "internal/ExtensionController.h"
 

--- a/src/controllers/DrumController.cpp
+++ b/src/controllers/DrumController.cpp
@@ -43,6 +43,10 @@ constexpr ByteMap DrumController_Shared::Maps::Velocity;
 constexpr ByteMap DrumController_Shared::Maps::VelocityID;
 constexpr BitMap  DrumController_Shared::Maps::VelocityAvailable;
 
+ExtensionType DrumController_Shared::getControllerType() const {
+	return ExtensionType::DrumController;
+}
+
 uint8_t DrumController_Shared::joyX() const {
 	return getControlData(Maps::JoyX);
 }

--- a/src/controllers/DrumController.cpp
+++ b/src/controllers/DrumController.cpp
@@ -43,7 +43,7 @@ constexpr ByteMap DrumControllerBase::Maps::Velocity;
 constexpr ByteMap DrumControllerBase::Maps::VelocityID;
 constexpr BitMap  DrumControllerBase::Maps::VelocityAvailable;
 
-ExtensionType DrumControllerBase::getControllerType() const {
+ExtensionType DrumControllerBase::getExpectedType() const {
 	return ExtensionType::DrumController;
 }
 

--- a/src/controllers/DrumController.cpp
+++ b/src/controllers/DrumController.cpp
@@ -24,74 +24,74 @@
 
 namespace NintendoExtensionCtrl {
 
-constexpr ByteMap DrumController_Shared::Maps::JoyX;
-constexpr ByteMap DrumController_Shared::Maps::JoyY;
+constexpr ByteMap DrumControllerBase::Maps::JoyX;
+constexpr ByteMap DrumControllerBase::Maps::JoyY;
 
-constexpr BitMap  DrumController_Shared::Maps::ButtonPlus;
-constexpr BitMap  DrumController_Shared::Maps::ButtonMinus;
+constexpr BitMap  DrumControllerBase::Maps::ButtonPlus;
+constexpr BitMap  DrumControllerBase::Maps::ButtonMinus;
 
-constexpr BitMap  DrumController_Shared::Maps::DrumRed;
-constexpr BitMap  DrumController_Shared::Maps::DrumBlue;
-constexpr BitMap  DrumController_Shared::Maps::DrumGreen;
+constexpr BitMap  DrumControllerBase::Maps::DrumRed;
+constexpr BitMap  DrumControllerBase::Maps::DrumBlue;
+constexpr BitMap  DrumControllerBase::Maps::DrumGreen;
 
-constexpr BitMap  DrumController_Shared::Maps::CymbalYellow;
-constexpr BitMap  DrumController_Shared::Maps::CymbalOrange;
+constexpr BitMap  DrumControllerBase::Maps::CymbalYellow;
+constexpr BitMap  DrumControllerBase::Maps::CymbalOrange;
 
-constexpr BitMap  DrumController_Shared::Maps::Pedal;
+constexpr BitMap  DrumControllerBase::Maps::Pedal;
 
-constexpr ByteMap DrumController_Shared::Maps::Velocity;
-constexpr ByteMap DrumController_Shared::Maps::VelocityID;
-constexpr BitMap  DrumController_Shared::Maps::VelocityAvailable;
+constexpr ByteMap DrumControllerBase::Maps::Velocity;
+constexpr ByteMap DrumControllerBase::Maps::VelocityID;
+constexpr BitMap  DrumControllerBase::Maps::VelocityAvailable;
 
-ExtensionType DrumController_Shared::getControllerType() const {
+ExtensionType DrumControllerBase::getControllerType() const {
 	return ExtensionType::DrumController;
 }
 
-uint8_t DrumController_Shared::joyX() const {
+uint8_t DrumControllerBase::joyX() const {
 	return getControlData(Maps::JoyX);
 }
 
-uint8_t DrumController_Shared::joyY() const {
+uint8_t DrumControllerBase::joyY() const {
 	return getControlData(Maps::JoyY);
 }
 
-boolean DrumController_Shared::drumRed() const {
+boolean DrumControllerBase::drumRed() const {
 	return getControlBit(Maps::DrumRed);
 }
 
-boolean DrumController_Shared::drumBlue() const {
+boolean DrumControllerBase::drumBlue() const {
 	return getControlBit(Maps::DrumBlue);
 }
 
-boolean DrumController_Shared::drumGreen() const {
+boolean DrumControllerBase::drumGreen() const {
 	return getControlBit(Maps::DrumGreen);
 }
 
-boolean DrumController_Shared::cymbalYellow() const {
+boolean DrumControllerBase::cymbalYellow() const {
 	return getControlBit(Maps::CymbalYellow);
 }
 
-boolean DrumController_Shared::cymbalOrange() const {
+boolean DrumControllerBase::cymbalOrange() const {
 	return getControlBit(Maps::CymbalOrange);
 }
 
-boolean DrumController_Shared::bassPedal() const {
+boolean DrumControllerBase::bassPedal() const {
 	return getControlBit(Maps::Pedal);
 }
 
-boolean DrumController_Shared::buttonPlus() const {
+boolean DrumControllerBase::buttonPlus() const {
 	return getControlBit(Maps::ButtonPlus);
 }
 
-boolean DrumController_Shared::buttonMinus() const {
+boolean DrumControllerBase::buttonMinus() const {
 	return getControlBit(Maps::ButtonMinus);
 }
 
-boolean DrumController_Shared::velocityAvailable() const {
+boolean DrumControllerBase::velocityAvailable() const {
 	return getControlBit(Maps::VelocityAvailable);
 }
 
-DrumController_Shared::VelocityID DrumController_Shared::velocityID() const {
+DrumControllerBase::VelocityID DrumControllerBase::velocityID() const {
 	uint8_t id = getControlData(Maps::VelocityID);  // 5 bit identifier
 
 	if (validVelocityID(id)) {
@@ -101,7 +101,7 @@ DrumController_Shared::VelocityID DrumController_Shared::velocityID() const {
 	return VelocityID::None;
 }
 
-boolean DrumController_Shared::validVelocityID(uint8_t idIn) const {
+boolean DrumControllerBase::validVelocityID(uint8_t idIn) const {
 	switch (idIn) {
 		case(VelocityID::None):  // Intentionally fall through cases
 		case(VelocityID::Red):
@@ -117,7 +117,7 @@ boolean DrumController_Shared::validVelocityID(uint8_t idIn) const {
 	}
 }
 
-uint8_t DrumController_Shared::velocity() const {
+uint8_t DrumControllerBase::velocity() const {
 	if (velocityAvailable()) {
 		uint8_t velocityRaw = getControlData(Maps::Velocity);
 		velocityRaw = 7 - velocityRaw;  // Invert so high = fast attack
@@ -126,38 +126,38 @@ uint8_t DrumController_Shared::velocity() const {
 	return 0;  // Invalid data
 }
 
-uint8_t DrumController_Shared::velocity(VelocityID idIn) const {
+uint8_t DrumControllerBase::velocity(VelocityID idIn) const {
 	if (idIn == velocityID()) {
 		return velocity();
 	}
 	return 0;  // ID mismatch
 }
 
-uint8_t DrumController_Shared::velocityRed() const {
+uint8_t DrumControllerBase::velocityRed() const {
 	return velocity(VelocityID::Red);
 }
 
-uint8_t DrumController_Shared::velocityBlue() const {
+uint8_t DrumControllerBase::velocityBlue() const {
 	return velocity(VelocityID::Blue);
 }
 
-uint8_t DrumController_Shared::velocityGreen() const {
+uint8_t DrumControllerBase::velocityGreen() const {
 	return velocity(VelocityID::Green);
 }
 
-uint8_t DrumController_Shared::velocityYellow() const {
+uint8_t DrumControllerBase::velocityYellow() const {
 	return velocity(VelocityID::Yellow);
 }
 
-uint8_t DrumController_Shared::velocityOrange() const {
+uint8_t DrumControllerBase::velocityOrange() const {
 	return velocity(VelocityID::Orange);
 }
 
-uint8_t DrumController_Shared::velocityPedal() const {
+uint8_t DrumControllerBase::velocityPedal() const {
 	return velocity(VelocityID::Pedal);
 }
 
-void DrumController_Shared::printDebug(Print& output) const {
+void DrumControllerBase::printDebug(Print& output) const {
 	const char fillCharacter = '_';
 	
 	char buffer[45];

--- a/src/controllers/DrumController.h
+++ b/src/controllers/DrumController.h
@@ -28,14 +28,14 @@
 #include "ClassicController.h"  // For joystick and +/- control maps
 
 namespace NintendoExtensionCtrl {
-	class DrumController_Shared : public ExtensionController {
+	class DrumControllerBase : public ExtensionController {
 	public:
 		struct Maps {
-			constexpr static ByteMap JoyX = ClassicController_Shared::Maps::LeftJoyX;
-			constexpr static ByteMap JoyY = ClassicController_Shared::Maps::LeftJoyY;
+			constexpr static ByteMap JoyX = ClassicControllerBase::Maps::LeftJoyX;
+			constexpr static ByteMap JoyY = ClassicControllerBase::Maps::LeftJoyY;
 
-			constexpr static BitMap  ButtonPlus = ClassicController_Shared::Maps::ButtonPlus;
-			constexpr static BitMap  ButtonMinus = ClassicController_Shared::Maps::ButtonMinus;
+			constexpr static BitMap  ButtonPlus = ClassicControllerBase::Maps::ButtonPlus;
+			constexpr static BitMap  ButtonMinus = ClassicControllerBase::Maps::ButtonMinus;
 
 			constexpr static BitMap  DrumRed = { 5, 6 };
 			constexpr static BitMap  DrumBlue = { 5, 3 };
@@ -51,11 +51,11 @@ namespace NintendoExtensionCtrl {
 			constexpr static BitMap  VelocityAvailable = { 2, 6 };
 		};
 
-		DrumController_Shared(ExtensionData &dataRef) :
+		DrumControllerBase(ExtensionData &dataRef) :
 			ExtensionController(dataRef) {}
 
-		DrumController_Shared(ExtensionPort &port) :
-			DrumController_Shared(port.getExtensionData()) {}
+		DrumControllerBase(ExtensionPort &port) :
+			DrumControllerBase(port.getExtensionData()) {}
 
 		ExtensionType getControllerType() const;
 
@@ -105,6 +105,6 @@ namespace NintendoExtensionCtrl {
 }
 
 using DrumController = NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::DrumController_Shared>;
+	<NintendoExtensionCtrl::DrumControllerBase>;
 
 #endif

--- a/src/controllers/DrumController.h
+++ b/src/controllers/DrumController.h
@@ -20,8 +20,8 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NXC_DrumController_h
-#define NXC_DrumController_h
+#ifndef NXC_DRUMCONTROLLER_H
+#define NXC_DRUMCONTROLLER_H
 
 #include "internal/ExtensionController.h"
 

--- a/src/controllers/DrumController.h
+++ b/src/controllers/DrumController.h
@@ -51,8 +51,7 @@ namespace NintendoExtensionCtrl {
 			constexpr static BitMap  VelocityAvailable = { 2, 6 };
 		};
 
-		DrumControllerBase(ExtensionData &dataRef) :
-			ExtensionController(dataRef) {}
+		using ExtensionController::ExtensionController;
 
 		ExtensionType getControllerType() const;
 

--- a/src/controllers/DrumController.h
+++ b/src/controllers/DrumController.h
@@ -52,10 +52,12 @@ namespace NintendoExtensionCtrl {
 		};
 
 		DrumController_Shared(ExtensionData &dataRef) :
-			ExtensionController(dataRef, ExtensionType::DrumController) {}
+			ExtensionController(dataRef) {}
 
 		DrumController_Shared(ExtensionPort &port) :
 			DrumController_Shared(port.getExtensionData()) {}
+
+		ExtensionType getControllerType() const;
 
 		enum VelocityID : uint8_t {
 			None = 0x1F,

--- a/src/controllers/DrumController.h
+++ b/src/controllers/DrumController.h
@@ -53,7 +53,7 @@ namespace NintendoExtensionCtrl {
 
 		using ExtensionController::ExtensionController;
 
-		ExtensionType getControllerType() const;
+		ExtensionType getExpectedType() const;
 
 		enum VelocityID : uint8_t {
 			None = 0x1F,

--- a/src/controllers/DrumController.h
+++ b/src/controllers/DrumController.h
@@ -54,9 +54,6 @@ namespace NintendoExtensionCtrl {
 		DrumControllerBase(ExtensionData &dataRef) :
 			ExtensionController(dataRef) {}
 
-		DrumControllerBase(ExtensionPort &port) :
-			DrumControllerBase(port.getExtensionData()) {}
-
 		ExtensionType getControllerType() const;
 
 		enum VelocityID : uint8_t {

--- a/src/controllers/GuitarController.cpp
+++ b/src/controllers/GuitarController.cpp
@@ -42,6 +42,10 @@ constexpr BitMap  GuitarController_Shared::Maps::FretOrange;
 constexpr ByteMap GuitarController_Shared::Maps::Whammy;
 constexpr ByteMap GuitarController_Shared::Maps::Touchbar;
 
+ExtensionType GuitarController_Shared::getControllerType() const {
+	return ExtensionType::GuitarController;
+}
+
 uint8_t GuitarController_Shared::joyX() const {
 	return getControlData(Maps::JoyX);
 }

--- a/src/controllers/GuitarController.cpp
+++ b/src/controllers/GuitarController.cpp
@@ -42,7 +42,7 @@ constexpr BitMap  GuitarControllerBase::Maps::FretOrange;
 constexpr ByteMap GuitarControllerBase::Maps::Whammy;
 constexpr ByteMap GuitarControllerBase::Maps::Touchbar;
 
-ExtensionType GuitarControllerBase::getControllerType() const {
+ExtensionType GuitarControllerBase::getExpectedType() const {
 	return ExtensionType::GuitarController;
 }
 

--- a/src/controllers/GuitarController.cpp
+++ b/src/controllers/GuitarController.cpp
@@ -24,106 +24,106 @@
 
 namespace NintendoExtensionCtrl {
 
-constexpr ByteMap GuitarController_Shared::Maps::JoyX;
-constexpr ByteMap GuitarController_Shared::Maps::JoyY;
+constexpr ByteMap GuitarControllerBase::Maps::JoyX;
+constexpr ByteMap GuitarControllerBase::Maps::JoyY;
 
-constexpr BitMap  GuitarController_Shared::Maps::ButtonPlus;
-constexpr BitMap  GuitarController_Shared::Maps::ButtonMinus;
+constexpr BitMap  GuitarControllerBase::Maps::ButtonPlus;
+constexpr BitMap  GuitarControllerBase::Maps::ButtonMinus;
 
-constexpr BitMap  GuitarController_Shared::Maps::StrumUp;
-constexpr BitMap  GuitarController_Shared::Maps::StrumDown;
+constexpr BitMap  GuitarControllerBase::Maps::StrumUp;
+constexpr BitMap  GuitarControllerBase::Maps::StrumDown;
 
-constexpr BitMap  GuitarController_Shared::Maps::FretGreen;
-constexpr BitMap  GuitarController_Shared::Maps::FretRed;
-constexpr BitMap  GuitarController_Shared::Maps::FretYellow;
-constexpr BitMap  GuitarController_Shared::Maps::FretBlue;
-constexpr BitMap  GuitarController_Shared::Maps::FretOrange;
+constexpr BitMap  GuitarControllerBase::Maps::FretGreen;
+constexpr BitMap  GuitarControllerBase::Maps::FretRed;
+constexpr BitMap  GuitarControllerBase::Maps::FretYellow;
+constexpr BitMap  GuitarControllerBase::Maps::FretBlue;
+constexpr BitMap  GuitarControllerBase::Maps::FretOrange;
 
-constexpr ByteMap GuitarController_Shared::Maps::Whammy;
-constexpr ByteMap GuitarController_Shared::Maps::Touchbar;
+constexpr ByteMap GuitarControllerBase::Maps::Whammy;
+constexpr ByteMap GuitarControllerBase::Maps::Touchbar;
 
-ExtensionType GuitarController_Shared::getControllerType() const {
+ExtensionType GuitarControllerBase::getControllerType() const {
 	return ExtensionType::GuitarController;
 }
 
-uint8_t GuitarController_Shared::joyX() const {
+uint8_t GuitarControllerBase::joyX() const {
 	return getControlData(Maps::JoyX);
 }
 
-uint8_t GuitarController_Shared::joyY() const {
+uint8_t GuitarControllerBase::joyY() const {
 	return getControlData(Maps::JoyY);
 }
 
-boolean GuitarController_Shared::strum() const {
+boolean GuitarControllerBase::strum() const {
 	return strumUp() | strumDown();
 }
 
-boolean GuitarController_Shared::strumUp() const {
+boolean GuitarControllerBase::strumUp() const {
 	return getControlBit(Maps::StrumUp);
 }
 
-boolean GuitarController_Shared::strumDown() const {
+boolean GuitarControllerBase::strumDown() const {
 	return getControlBit(Maps::StrumDown);
 }
 
-boolean GuitarController_Shared::fretGreen() const {
+boolean GuitarControllerBase::fretGreen() const {
 	return getControlBit(Maps::FretGreen);
 }
 
-boolean GuitarController_Shared::fretRed() const {
+boolean GuitarControllerBase::fretRed() const {
 	return getControlBit(Maps::FretRed);
 }
 
-boolean GuitarController_Shared::fretYellow() const {
+boolean GuitarControllerBase::fretYellow() const {
 	return getControlBit(Maps::FretYellow);
 }
 
-boolean GuitarController_Shared::fretBlue() const {
+boolean GuitarControllerBase::fretBlue() const {
 	return getControlBit(Maps::FretBlue);
 }
 
-boolean GuitarController_Shared::fretOrange() const {
+boolean GuitarControllerBase::fretOrange() const {
 	return getControlBit(Maps::FretOrange);
 }
 
-uint8_t GuitarController_Shared::whammyBar() const {
+uint8_t GuitarControllerBase::whammyBar() const {
 	return getControlData(Maps::Whammy);
 }
 
-uint8_t GuitarController_Shared::touchbar() const {
+uint8_t GuitarControllerBase::touchbar() const {
 	return getControlData(Maps::Touchbar);
 }
 
-boolean GuitarController_Shared::touchGreen() const {
+boolean GuitarControllerBase::touchGreen() const {
 	return touchbar() != 0 && touchbar() <= 7;
 }
 
-boolean GuitarController_Shared::touchRed() const {
+boolean GuitarControllerBase::touchRed() const {
 	return touchbar() >= 7 && touchbar() <= 13;
 }
 
-boolean GuitarController_Shared::touchYellow() const {
+boolean GuitarControllerBase::touchYellow() const {
 	return touchbar() >= 12 && touchbar() <= 21
 		&& touchbar() != 15;	// The "not touched" value
 }
 
-boolean GuitarController_Shared::touchBlue() const {
+boolean GuitarControllerBase::touchBlue() const {
 	return touchbar() >= 20 && touchbar() <= 26;
 }
 
-boolean GuitarController_Shared::touchOrange() const {
+boolean GuitarControllerBase::touchOrange() const {
 	return touchbar() >= 26;
 }
 
-boolean GuitarController_Shared::buttonPlus() const {
+boolean GuitarControllerBase::buttonPlus() const {
 	return getControlBit(Maps::ButtonPlus);
 }
 
-boolean GuitarController_Shared::buttonMinus() const {
+boolean GuitarControllerBase::buttonMinus() const {
 	return getControlBit(Maps::ButtonMinus);
 }
 
-boolean GuitarController_Shared::supportsTouchbar() {
+boolean GuitarControllerBase::supportsTouchbar() {
 	if (touchbarData) {
 		return true;
 	}
@@ -133,7 +133,7 @@ boolean GuitarController_Shared::supportsTouchbar() {
 	return false;
 }
 
-void GuitarController_Shared::printDebug(Print& output) {
+void GuitarControllerBase::printDebug(Print& output) {
 	const char fillCharacter = '_';
 
 	char buffer[25];

--- a/src/controllers/GuitarController.h
+++ b/src/controllers/GuitarController.h
@@ -52,7 +52,7 @@ namespace NintendoExtensionCtrl {
 
 		using ExtensionController::ExtensionController;
 
-		ExtensionType getControllerType() const;
+		ExtensionType getExpectedType() const;
 
 		uint8_t joyX() const;  // 6 bits, 0-63
 		uint8_t joyY() const;

--- a/src/controllers/GuitarController.h
+++ b/src/controllers/GuitarController.h
@@ -50,8 +50,7 @@ namespace NintendoExtensionCtrl {
 			constexpr static ByteMap Touchbar = ByteMap(2, 5, 0, 0);
 		};
 
-		GuitarControllerBase(ExtensionData &dataRef) :
-			ExtensionController(dataRef) {}
+		using ExtensionController::ExtensionController;
 
 		ExtensionType getControllerType() const;
 

--- a/src/controllers/GuitarController.h
+++ b/src/controllers/GuitarController.h
@@ -51,10 +51,12 @@ namespace NintendoExtensionCtrl {
 		};
 
 		GuitarController_Shared(ExtensionData &dataRef) :
-			ExtensionController(dataRef, ExtensionType::GuitarController) {}
+			ExtensionController(dataRef) {}
 
 		GuitarController_Shared(ExtensionPort &port) :
 			GuitarController_Shared(port.getExtensionData()) {}
+
+		ExtensionType getControllerType() const;
 
 		uint8_t joyX() const;  // 6 bits, 0-63
 		uint8_t joyY() const;

--- a/src/controllers/GuitarController.h
+++ b/src/controllers/GuitarController.h
@@ -20,8 +20,8 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NXC_GuitarController_h
-#define NXC_GuitarController_h
+#ifndef NXC_GUITARCONTROLLER_H
+#define NXC_GUITARCONTROLLER_H
 
 #include "internal/ExtensionController.h"
 

--- a/src/controllers/GuitarController.h
+++ b/src/controllers/GuitarController.h
@@ -53,9 +53,6 @@ namespace NintendoExtensionCtrl {
 		GuitarControllerBase(ExtensionData &dataRef) :
 			ExtensionController(dataRef) {}
 
-		GuitarControllerBase(ExtensionPort &port) :
-			GuitarControllerBase(port.getExtensionData()) {}
-
 		ExtensionType getControllerType() const;
 
 		uint8_t joyX() const;  // 6 bits, 0-63

--- a/src/controllers/GuitarController.h
+++ b/src/controllers/GuitarController.h
@@ -28,14 +28,14 @@
 #include "ClassicController.h"  // For joystick and +/- control maps
 
 namespace NintendoExtensionCtrl {
-	class GuitarController_Shared : public ExtensionController {
+	class GuitarControllerBase : public ExtensionController {
 	public:
 		struct Maps {
-			constexpr static ByteMap JoyX = ClassicController_Shared::Maps::LeftJoyX;
-			constexpr static ByteMap JoyY = ClassicController_Shared::Maps::LeftJoyY;
+			constexpr static ByteMap JoyX = ClassicControllerBase::Maps::LeftJoyX;
+			constexpr static ByteMap JoyY = ClassicControllerBase::Maps::LeftJoyY;
 
-			constexpr static BitMap  ButtonPlus = ClassicController_Shared::Maps::ButtonPlus;
-			constexpr static BitMap  ButtonMinus = ClassicController_Shared::Maps::ButtonMinus;
+			constexpr static BitMap  ButtonPlus = ClassicControllerBase::Maps::ButtonPlus;
+			constexpr static BitMap  ButtonMinus = ClassicControllerBase::Maps::ButtonMinus;
 
 			constexpr static BitMap  StrumUp = { 5, 0 };
 			constexpr static BitMap  StrumDown = { 4, 6 };
@@ -50,11 +50,11 @@ namespace NintendoExtensionCtrl {
 			constexpr static ByteMap Touchbar = ByteMap(2, 5, 0, 0);
 		};
 
-		GuitarController_Shared(ExtensionData &dataRef) :
+		GuitarControllerBase(ExtensionData &dataRef) :
 			ExtensionController(dataRef) {}
 
-		GuitarController_Shared(ExtensionPort &port) :
-			GuitarController_Shared(port.getExtensionData()) {}
+		GuitarControllerBase(ExtensionPort &port) :
+			GuitarControllerBase(port.getExtensionData()) {}
 
 		ExtensionType getControllerType() const;
 
@@ -93,6 +93,6 @@ namespace NintendoExtensionCtrl {
 }
 
 using GuitarController = NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::GuitarController_Shared>;
+	<NintendoExtensionCtrl::GuitarControllerBase>;
 
 #endif

--- a/src/controllers/Nunchuk.cpp
+++ b/src/controllers/Nunchuk.cpp
@@ -24,63 +24,63 @@
 
 namespace NintendoExtensionCtrl {
 
-constexpr IndexMap Nunchuk_Shared::Maps::JoyX;
-constexpr IndexMap Nunchuk_Shared::Maps::JoyY;
+constexpr IndexMap NunchukBase::Maps::JoyX;
+constexpr IndexMap NunchukBase::Maps::JoyY;
 
-constexpr IndexMap Nunchuk_Shared::Maps::AccelX_MSB;
-constexpr ByteMap  Nunchuk_Shared::Maps::AccelX_LSB;
+constexpr IndexMap NunchukBase::Maps::AccelX_MSB;
+constexpr ByteMap  NunchukBase::Maps::AccelX_LSB;
 
-constexpr IndexMap Nunchuk_Shared::Maps::AccelY_MSB;
-constexpr ByteMap  Nunchuk_Shared::Maps::AccelY_LSB;
+constexpr IndexMap NunchukBase::Maps::AccelY_MSB;
+constexpr ByteMap  NunchukBase::Maps::AccelY_LSB;
 
-constexpr IndexMap Nunchuk_Shared::Maps::AccelZ_MSB;
-constexpr ByteMap  Nunchuk_Shared::Maps::AccelZ_LSB;
+constexpr IndexMap NunchukBase::Maps::AccelZ_MSB;
+constexpr ByteMap  NunchukBase::Maps::AccelZ_LSB;
 
-constexpr BitMap   Nunchuk_Shared::Maps::ButtonC;
-constexpr BitMap   Nunchuk_Shared::Maps::ButtonZ;
+constexpr BitMap   NunchukBase::Maps::ButtonC;
+constexpr BitMap   NunchukBase::Maps::ButtonZ;
 
-ExtensionType Nunchuk_Shared::getControllerType() const {
+ExtensionType NunchukBase::getControllerType() const {
 	return ExtensionType::Nunchuk;
 }
 
-uint8_t Nunchuk_Shared::joyX() const {
+uint8_t NunchukBase::joyX() const {
 	return getControlData(Maps::JoyX);
 }
 
-uint8_t Nunchuk_Shared::joyY() const {
+uint8_t NunchukBase::joyY() const {
 	return getControlData(Maps::JoyY);
 }
 
-uint16_t Nunchuk_Shared::accelX() const {
+uint16_t NunchukBase::accelX() const {
 	return (getControlData(Maps::AccelX_MSB) << 2) | getControlData(Maps::AccelX_LSB);
 }
 
-uint16_t Nunchuk_Shared::accelY() const {
+uint16_t NunchukBase::accelY() const {
 	return (getControlData(Maps::AccelY_MSB) << 2) | getControlData(Maps::AccelY_LSB);
 }
 
-uint16_t Nunchuk_Shared::accelZ() const {
+uint16_t NunchukBase::accelZ() const {
 	return (getControlData(Maps::AccelZ_MSB) << 2) | getControlData(Maps::AccelZ_LSB);
 }
 
-boolean Nunchuk_Shared::buttonC() const {
+boolean NunchukBase::buttonC() const {
 	return getControlBit(Maps::ButtonC);
 }
 
-boolean Nunchuk_Shared::buttonZ() const {
+boolean NunchukBase::buttonZ() const {
 	return getControlBit(Maps::ButtonZ);
 }
 
-float Nunchuk_Shared::rollAngle() const {
+float NunchukBase::rollAngle() const {
 	return atan2((float)accelX() - 511.0, (float)accelZ() - 511.0) * 180.0 / PI;
 }
 
-float Nunchuk_Shared::pitchAngle() const {
+float NunchukBase::pitchAngle() const {
 	// Inverted so pulling back is a positive pitch
 	return -atan2((float)accelY() - 511.0, (float)accelZ() - 511.0) * 180.0 / PI;
 }
 
-void Nunchuk_Shared::printDebug(Print& output) const {
+void NunchukBase::printDebug(Print& output) const {
 	char buffer[60];
 
 	char cPrint = buttonC() ? 'C' : '-';

--- a/src/controllers/Nunchuk.cpp
+++ b/src/controllers/Nunchuk.cpp
@@ -39,7 +39,7 @@ constexpr ByteMap  NunchukBase::Maps::AccelZ_LSB;
 constexpr BitMap   NunchukBase::Maps::ButtonC;
 constexpr BitMap   NunchukBase::Maps::ButtonZ;
 
-ExtensionType NunchukBase::getControllerType() const {
+ExtensionType NunchukBase::getExpectedType() const {
 	return ExtensionType::Nunchuk;
 }
 

--- a/src/controllers/Nunchuk.cpp
+++ b/src/controllers/Nunchuk.cpp
@@ -39,6 +39,10 @@ constexpr ByteMap  Nunchuk_Shared::Maps::AccelZ_LSB;
 constexpr BitMap   Nunchuk_Shared::Maps::ButtonC;
 constexpr BitMap   Nunchuk_Shared::Maps::ButtonZ;
 
+ExtensionType Nunchuk_Shared::getControllerType() const {
+	return ExtensionType::Nunchuk;
+}
+
 uint8_t Nunchuk_Shared::joyX() const {
 	return getControlData(Maps::JoyX);
 }

--- a/src/controllers/Nunchuk.h
+++ b/src/controllers/Nunchuk.h
@@ -47,7 +47,7 @@ namespace NintendoExtensionCtrl {
 		
 		using ExtensionController::ExtensionController;
 
-		ExtensionType getControllerType() const;
+		ExtensionType getExpectedType() const;
 
 		uint8_t joyX() const;  // 8 bits, 0-255
 		uint8_t joyY() const;

--- a/src/controllers/Nunchuk.h
+++ b/src/controllers/Nunchuk.h
@@ -45,8 +45,7 @@ namespace NintendoExtensionCtrl {
 			constexpr static BitMap   ButtonZ = { 5, 0 };
 		};
 		
-		NunchukBase(ExtensionData &dataRef) :
-			ExtensionController(dataRef) {}
+		using ExtensionController::ExtensionController;
 
 		ExtensionType getControllerType() const;
 

--- a/src/controllers/Nunchuk.h
+++ b/src/controllers/Nunchuk.h
@@ -20,8 +20,8 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NXC_Nunchuk_h
-#define NXC_Nunchuk_h
+#ifndef NXC_NUNCHUK_H
+#define NXC_NUNCHUK_H
 
 #include "internal/ExtensionController.h"
 

--- a/src/controllers/Nunchuk.h
+++ b/src/controllers/Nunchuk.h
@@ -26,7 +26,7 @@
 #include "internal/ExtensionController.h"
 
 namespace NintendoExtensionCtrl {
-	class Nunchuk_Shared : public ExtensionController {
+	class NunchukBase : public ExtensionController {
 	public:
 		struct Maps {
 			constexpr static IndexMap JoyX = 0;
@@ -45,11 +45,11 @@ namespace NintendoExtensionCtrl {
 			constexpr static BitMap   ButtonZ = { 5, 0 };
 		};
 		
-		Nunchuk_Shared(ExtensionData &dataRef) :
+		NunchukBase(ExtensionData &dataRef) :
 			ExtensionController(dataRef) {}
 
-		Nunchuk_Shared(ExtensionPort &port) :
-			Nunchuk_Shared(port.getExtensionData()) {}
+		NunchukBase(ExtensionPort &port) :
+			NunchukBase(port.getExtensionData()) {}
 
 		ExtensionType getControllerType() const;
 
@@ -71,6 +71,6 @@ namespace NintendoExtensionCtrl {
 }
 
 using Nunchuk = NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::Nunchuk_Shared>;
+	<NintendoExtensionCtrl::NunchukBase>;
 
 #endif

--- a/src/controllers/Nunchuk.h
+++ b/src/controllers/Nunchuk.h
@@ -48,9 +48,6 @@ namespace NintendoExtensionCtrl {
 		NunchukBase(ExtensionData &dataRef) :
 			ExtensionController(dataRef) {}
 
-		NunchukBase(ExtensionPort &port) :
-			NunchukBase(port.getExtensionData()) {}
-
 		ExtensionType getControllerType() const;
 
 		uint8_t joyX() const;  // 8 bits, 0-255

--- a/src/controllers/Nunchuk.h
+++ b/src/controllers/Nunchuk.h
@@ -46,10 +46,12 @@ namespace NintendoExtensionCtrl {
 		};
 		
 		Nunchuk_Shared(ExtensionData &dataRef) :
-			ExtensionController(dataRef, ExtensionType::Nunchuk) {}
+			ExtensionController(dataRef) {}
 
 		Nunchuk_Shared(ExtensionPort &port) :
 			Nunchuk_Shared(port.getExtensionData()) {}
+
+		ExtensionType getControllerType() const;
 
 		uint8_t joyX() const;  // 8 bits, 0-255
 		uint8_t joyY() const;

--- a/src/controllers/uDrawTablet.cpp
+++ b/src/controllers/uDrawTablet.cpp
@@ -35,6 +35,10 @@ constexpr BitMap   uDrawTablet_Shared::Maps::Pressure_MSB;
 constexpr BitMap   uDrawTablet_Shared::Maps::buttonLower;
 constexpr BitMap   uDrawTablet_Shared::Maps::buttonUpper;
 
+ExtensionType uDrawTablet_Shared::getControllerType() const {
+	return ExtensionType::uDrawTablet;
+}
+
 uint16_t uDrawTablet_Shared::penX() const {
 	return (getControlData(Maps::PenX_MSB) << 8) | getControlData(Maps::PenX_LSB);
 }

--- a/src/controllers/uDrawTablet.cpp
+++ b/src/controllers/uDrawTablet.cpp
@@ -24,46 +24,46 @@
 
 namespace NintendoExtensionCtrl {
 
-constexpr IndexMap uDrawTablet_Shared::Maps::PenX_LSB;
-constexpr IndexMap uDrawTablet_Shared::Maps::PenY_LSB;
-constexpr ByteMap  uDrawTablet_Shared::Maps::PenX_MSB;
-constexpr ByteMap  uDrawTablet_Shared::Maps::PenY_MSB;
+constexpr IndexMap uDrawTabletBase::Maps::PenX_LSB;
+constexpr IndexMap uDrawTabletBase::Maps::PenY_LSB;
+constexpr ByteMap  uDrawTabletBase::Maps::PenX_MSB;
+constexpr ByteMap  uDrawTabletBase::Maps::PenY_MSB;
 
-constexpr IndexMap uDrawTablet_Shared::Maps::Pressure_LSB;
-constexpr BitMap   uDrawTablet_Shared::Maps::Pressure_MSB;
+constexpr IndexMap uDrawTabletBase::Maps::Pressure_LSB;
+constexpr BitMap   uDrawTabletBase::Maps::Pressure_MSB;
 
-constexpr BitMap   uDrawTablet_Shared::Maps::buttonLower;
-constexpr BitMap   uDrawTablet_Shared::Maps::buttonUpper;
+constexpr BitMap   uDrawTabletBase::Maps::buttonLower;
+constexpr BitMap   uDrawTabletBase::Maps::buttonUpper;
 
-ExtensionType uDrawTablet_Shared::getControllerType() const {
+ExtensionType uDrawTabletBase::getControllerType() const {
 	return ExtensionType::uDrawTablet;
 }
 
-uint16_t uDrawTablet_Shared::penX() const {
+uint16_t uDrawTabletBase::penX() const {
 	return (getControlData(Maps::PenX_MSB) << 8) | getControlData(Maps::PenX_LSB);
 }
 
-uint16_t uDrawTablet_Shared::penY() const {
+uint16_t uDrawTabletBase::penY() const {
 	return (getControlData(Maps::PenY_MSB) << 8) | getControlData(Maps::PenY_LSB);
 }
 
-uint16_t uDrawTablet_Shared::penPressure() const {
+uint16_t uDrawTabletBase::penPressure() const {
     return (!getControlBit(Maps::Pressure_MSB) << 8) | getControlData(Maps::Pressure_LSB);
 }
 
-boolean uDrawTablet_Shared::buttonLower() const {
+boolean uDrawTabletBase::buttonLower() const {
 	return getControlBit(Maps::buttonLower);
 }
 
-boolean uDrawTablet_Shared::buttonUpper() const {
+boolean uDrawTabletBase::buttonUpper() const {
 	return getControlBit(Maps::buttonUpper);
 }
 
-boolean uDrawTablet_Shared::penDetected() const {
+boolean uDrawTabletBase::penDetected() const {
 	return penX() < 4095 && penY() < 4095;
 }
 
-void uDrawTablet_Shared::printDebug(Print& output) const {
+void uDrawTabletBase::printDebug(Print& output) const {
 	char buffer[60];
 	
 	char penPrint = penDetected() ? 'Y' : 'N';

--- a/src/controllers/uDrawTablet.cpp
+++ b/src/controllers/uDrawTablet.cpp
@@ -35,7 +35,7 @@ constexpr BitMap   uDrawTabletBase::Maps::Pressure_MSB;
 constexpr BitMap   uDrawTabletBase::Maps::buttonLower;
 constexpr BitMap   uDrawTabletBase::Maps::buttonUpper;
 
-ExtensionType uDrawTabletBase::getControllerType() const {
+ExtensionType uDrawTabletBase::getExpectedType() const {
 	return ExtensionType::uDrawTablet;
 }
 

--- a/src/controllers/uDrawTablet.h
+++ b/src/controllers/uDrawTablet.h
@@ -41,8 +41,7 @@ namespace NintendoExtensionCtrl {
 			constexpr static BitMap   buttonUpper = { 5, 0 };
 		};
 		
-		uDrawTabletBase(ExtensionData &dataRef) :
-			ExtensionController(dataRef) {}
+		using ExtensionController::ExtensionController;
 
 		ExtensionType getControllerType() const;
 

--- a/src/controllers/uDrawTablet.h
+++ b/src/controllers/uDrawTablet.h
@@ -44,9 +44,6 @@ namespace NintendoExtensionCtrl {
 		uDrawTabletBase(ExtensionData &dataRef) :
 			ExtensionController(dataRef) {}
 
-		uDrawTabletBase(ExtensionPort &port) :
-			uDrawTabletBase(port.getExtensionData()) {}
-
 		ExtensionType getControllerType() const;
 
 		uint16_t penX() const;  // 12 bits, 0-4095

--- a/src/controllers/uDrawTablet.h
+++ b/src/controllers/uDrawTablet.h
@@ -20,8 +20,8 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NXC_uDrawTablet_h
-#define NXC_uDrawTablet_h
+#ifndef NXC_UDRAWTABLET_H
+#define NXC_UDRAWTABLET_H
 
 #include "internal/ExtensionController.h"
 

--- a/src/controllers/uDrawTablet.h
+++ b/src/controllers/uDrawTablet.h
@@ -26,7 +26,7 @@
 #include "internal/ExtensionController.h"
 
 namespace NintendoExtensionCtrl {
-	class uDrawTablet_Shared : public ExtensionController {
+	class uDrawTabletBase : public ExtensionController {
 	public:
 		struct Maps {
 			constexpr static IndexMap PenX_LSB = 0;
@@ -41,11 +41,11 @@ namespace NintendoExtensionCtrl {
 			constexpr static BitMap   buttonUpper = { 5, 0 };
 		};
 		
-		uDrawTablet_Shared(ExtensionData &dataRef) :
+		uDrawTabletBase(ExtensionData &dataRef) :
 			ExtensionController(dataRef) {}
 
-		uDrawTablet_Shared(ExtensionPort &port) :
-			uDrawTablet_Shared(port.getExtensionData()) {}
+		uDrawTabletBase(ExtensionPort &port) :
+			uDrawTabletBase(port.getExtensionData()) {}
 
 		ExtensionType getControllerType() const;
 
@@ -64,6 +64,6 @@ namespace NintendoExtensionCtrl {
 }
 
 using uDrawTablet = NintendoExtensionCtrl::BuildControllerClass
-	<NintendoExtensionCtrl::uDrawTablet_Shared>;
+	<NintendoExtensionCtrl::uDrawTabletBase>;
 
 #endif

--- a/src/controllers/uDrawTablet.h
+++ b/src/controllers/uDrawTablet.h
@@ -43,7 +43,7 @@ namespace NintendoExtensionCtrl {
 		
 		using ExtensionController::ExtensionController;
 
-		ExtensionType getControllerType() const;
+		ExtensionType getExpectedType() const;
 
 		uint16_t penX() const;  // 12 bits, 0-4095
 		uint16_t penY() const;

--- a/src/controllers/uDrawTablet.h
+++ b/src/controllers/uDrawTablet.h
@@ -42,10 +42,12 @@ namespace NintendoExtensionCtrl {
 		};
 		
 		uDrawTablet_Shared(ExtensionData &dataRef) :
-			ExtensionController(dataRef, ExtensionType::uDrawTablet) {}
+			ExtensionController(dataRef) {}
 
 		uDrawTablet_Shared(ExtensionPort &port) :
 			uDrawTablet_Shared(port.getExtensionData()) {}
+
+		ExtensionType getControllerType() const;
 
 		uint16_t penX() const;  // 12 bits, 0-4095
 		uint16_t penY() const;

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -25,10 +25,7 @@
 using namespace NintendoExtensionCtrl;
 
 ExtensionController::ExtensionController(ExtensionData& dataRef)
-	: ExtensionController(dataRef, ExtensionType::AnyController) {}
-
-ExtensionController::ExtensionController(ExtensionData& dataRef, ExtensionType conID)
-	: id(conID), data(dataRef)  {}
+	: data(dataRef)  {}
 
 void ExtensionController::begin() {
 	data.i2c.begin();  // Initialize the bus
@@ -64,6 +61,8 @@ void ExtensionController::reset() {
 }
 
 boolean ExtensionController::controllerTypeMatches() const {
+	const ExtensionType id = getControllerType();
+
 	if (data.connectedType == id) {
 		return true;  // Match!
 	}
@@ -75,6 +74,10 @@ boolean ExtensionController::controllerTypeMatches() const {
 }
 
 ExtensionType ExtensionController::getControllerType() const {
+	return ExtensionType::AnyController;
+}
+
+ExtensionType ExtensionController::getConnectedType() const {
 	return data.connectedType;
 }
 

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -77,7 +77,7 @@ ExtensionType ExtensionController::getExpectedType() const {
 	return ExtensionType::AnyController;
 }
 
-ExtensionType ExtensionController::getConnectedType() const {
+ExtensionType ExtensionController::getControllerType() const {
 	return data.connectedType;
 }
 

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -22,7 +22,7 @@
 
 #include "ExtensionController.h"
 
-using namespace NintendoExtensionCtrl;
+namespace NintendoExtensionCtrl {
 
 ExtensionController::ExtensionController(ExtensionData& dataRef)
 	: data(dataRef)  {}
@@ -193,7 +193,7 @@ ExtensionType ExtensionController::identifyController(NXC_I2C_TYPE& i2c) {
 
 // port-specific connect function that utilizes the linked list to evaluate
 // each attached controller variant automatically
-boolean NintendoExtensionCtrl::ExtensionPort::connect() {
+boolean ExtensionPort::connect() {
 	// start by running the default 'connect' function, looking for any controller
 	boolean success = ExtensionController::connect();
 
@@ -221,3 +221,5 @@ boolean NintendoExtensionCtrl::ExtensionPort::connect() {
 
 	return success;
 }
+
+}  // End NintendoExtensionCtrl namespace

--- a/src/internal/ExtensionController.cpp
+++ b/src/internal/ExtensionController.cpp
@@ -61,7 +61,7 @@ void ExtensionController::reset() {
 }
 
 boolean ExtensionController::controllerTypeMatches() const {
-	const ExtensionType id = getControllerType();
+	const ExtensionType id = getExpectedType();
 
 	if (data.connectedType == id) {
 		return true;  // Match!
@@ -73,7 +73,7 @@ boolean ExtensionController::controllerTypeMatches() const {
 	return false;  // Enforced types or no controller connected
 }
 
-ExtensionType ExtensionController::getControllerType() const {
+ExtensionType ExtensionController::getExpectedType() const {
 	return ExtensionType::AnyController;
 }
 

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -61,7 +61,7 @@ namespace NintendoExtensionCtrl {
 		void reset();
 
 		virtual ExtensionType getExpectedType() const;
-		ExtensionType getConnectedType() const;
+		ExtensionType getControllerType() const;
 		boolean controllerTypeMatches() const;
 
 		uint8_t getControlData(uint8_t controlIndex) const;

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -60,7 +60,7 @@ namespace NintendoExtensionCtrl {
 
 		void reset();
 
-		virtual ExtensionType getControllerType() const;
+		virtual ExtensionType getExpectedType() const;
 		ExtensionType getConnectedType() const;
 		boolean controllerTypeMatches() const;
 

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -20,8 +20,8 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NXC_ExtensionController_h
-#define NXC_ExtensionController_h
+#ifndef NXC_EXTENSIONCONTROLLER_H
+#define NXC_EXTENSIONCONTROLLER_H
 
 #include "NXC_Identity.h"
 #include "NXC_Comms.h"

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -27,6 +27,7 @@
 #include "NXC_Comms.h"
 #include "NXC_Utils.h"
 #include "NXC_DataMaps.h"
+#include "NXC_LinkedList.h"
 
 class ExtensionController {
 public:

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -29,116 +29,118 @@
 #include "NXC_DataMaps.h"
 #include "NXC_LinkedList.h"
 
-class ExtensionController {
-public:
-	struct ExtensionData {
-		friend class ExtensionController;
-
-		ExtensionData(NXC_I2C_TYPE& i2cbus) :
-			i2c(i2cbus) {}
-
-		static const uint8_t ControlDataSize = 21;  // Largest reporting mode (0x3d)
-
-	private:
-		NXC_I2C_TYPE & i2c;  // Reference for the I2C (Wire) class
-		ExtensionType connectedType = ExtensionType::NoController;
-		uint8_t requestSize = MinRequestSize;
-		uint8_t controlData[ControlDataSize];
-	};
-
-	ExtensionController(ExtensionData& dataRef);
-
-	void begin();
-
-	boolean connect();
-	virtual boolean specificInit();
-
-	boolean update();
-
-	void reset();
-
-	virtual ExtensionType getControllerType() const;
-	ExtensionType getConnectedType() const;
-	boolean controllerTypeMatches() const;
-
-	uint8_t getControlData(uint8_t controlIndex) const;
-	ExtensionData & getExtensionData() const;
-
-	size_t getRequestSize() const;
-	void setRequestSize(size_t size = MinRequestSize);
-
-	void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
-	void printDebugID(Print& output = NXC_SERIAL_DEFAULT) const;
-	void printDebugRaw(Print& output = NXC_SERIAL_DEFAULT) const;
-	void printDebugRaw(uint8_t baseFormat, Print& output = NXC_SERIAL_DEFAULT) const;
-
-	static const uint8_t MinRequestSize = 6;   // Smallest reporting mode (0x37)
-	static const uint8_t MaxRequestSize = ExtensionData::ControlDataSize;
-
-	NXC_I2C_TYPE& i2c() const;  // Easily accessible I2C reference
-
-	static const uint8_t I2C_Addr = 0x52;  // Address for all extension controllers
-	static const uint8_t ID_Size = 6;  // Number of bytes for ID signature
-
-public:
-	/* I2C Communication Functions, Static & Shared */
-	static boolean initialize(NXC_I2C_TYPE& i2c);
-
-	static boolean writeRegister(NXC_I2C_TYPE& i2c, byte reg, byte value);
-	static boolean readRegister(NXC_I2C_TYPE& i2c, byte reg, uint8_t* dataOut);
-	static uint8_t readRegister(NXC_I2C_TYPE& i2c, byte reg);  // no error reporting
-
-	static boolean requestData(NXC_I2C_TYPE& i2c, uint8_t ptr, size_t size, uint8_t* dataOut);
-	static boolean requestControlData(NXC_I2C_TYPE& i2c, size_t size, uint8_t* controlData);
-	static boolean requestIdentity(NXC_I2C_TYPE& i2c, uint8_t* idData);
-
-	static ExtensionType identifyController(NXC_I2C_TYPE& i2c);
-
-	/* I2C Communication Functions, Inline Member */
-	inline boolean initialize() const { return initialize(data.i2c); }
-
-	inline boolean writeRegister(byte reg, byte value) const { return writeRegister(data.i2c, reg, value); }
-	inline boolean readRegister(byte reg, uint8_t* dataOut) const { return readRegister(data.i2c, reg, dataOut); }
-	inline uint8_t readRegister(byte reg) const { return readRegister(data.i2c, reg); }
-
-	inline boolean requestData(uint8_t ptr, size_t size, uint8_t* dataOut) const { return requestData(data.i2c, ptr, size, dataOut); }
-	inline boolean requestControlData(size_t size, uint8_t* controlData) const { return requestControlData(data.i2c, size, controlData); }
-	inline boolean requestIdentity(uint8_t* idData) const { return requestIdentity(data.i2c, idData); }
-
-	inline ExtensionType identifyController() const { return data.connectedType = identifyController(data.i2c); }
-
-protected:
-	typedef NintendoExtensionCtrl::IndexMap  IndexMap;
-	typedef NintendoExtensionCtrl::ByteMap   ByteMap;
-	typedef NintendoExtensionCtrl::BitMap    BitMap;
-
-	uint8_t getControlData(const ByteMap map) const {
-		return (data.controlData[map.index] & map.mask) >> map.offset;
-	}
-
-	template<size_t size>
-	uint8_t getControlData(const ByteMap(&map)[size]) const {
-		uint8_t dataOut = 0x00;
-		for (size_t i = 0; i < size; i++) {
-			/* Repeated line from the single-ByteMap function above. Apparently the
-				constexpr stuff doesn't like being passed through nested functions. */
-			dataOut |= (data.controlData[map[i].index] & map[i].mask) >> map[i].offset;
-			//dataOut |= getControlData(map[i]);
-		}
-		return dataOut;
-	}
-
-	boolean getControlBit(const BitMap map) const {
-		return !(data.controlData[map.index] & (1 << map.position));  // Inverted logic, '0' is pressed
-	}
-
-	void setControlData(uint8_t index, uint8_t val);
-
-private:
-	ExtensionData &data;  // I2C and shared connection data
-};
 
 namespace NintendoExtensionCtrl {
+
+	class ExtensionController {
+	public:
+		struct ExtensionData {
+			friend class ExtensionController;
+
+			ExtensionData(NXC_I2C_TYPE& i2cbus) :
+				i2c(i2cbus) {}
+
+			static const uint8_t ControlDataSize = 21;  // Largest reporting mode (0x3d)
+
+		private:
+			NXC_I2C_TYPE & i2c;  // Reference for the I2C (Wire) class
+			ExtensionType connectedType = ExtensionType::NoController;
+			uint8_t requestSize = MinRequestSize;
+			uint8_t controlData[ControlDataSize];
+		};
+
+		ExtensionController(ExtensionData& dataRef);
+
+		void begin();
+
+		boolean connect();
+		virtual boolean specificInit();
+
+		boolean update();
+
+		void reset();
+
+		virtual ExtensionType getControllerType() const;
+		ExtensionType getConnectedType() const;
+		boolean controllerTypeMatches() const;
+
+		uint8_t getControlData(uint8_t controlIndex) const;
+		ExtensionData & getExtensionData() const;
+
+		size_t getRequestSize() const;
+		void setRequestSize(size_t size = MinRequestSize);
+
+		void printDebug(Print& output = NXC_SERIAL_DEFAULT) const;
+		void printDebugID(Print& output = NXC_SERIAL_DEFAULT) const;
+		void printDebugRaw(Print& output = NXC_SERIAL_DEFAULT) const;
+		void printDebugRaw(uint8_t baseFormat, Print& output = NXC_SERIAL_DEFAULT) const;
+
+		static const uint8_t MinRequestSize = 6;   // Smallest reporting mode (0x37)
+		static const uint8_t MaxRequestSize = ExtensionData::ControlDataSize;
+
+		NXC_I2C_TYPE& i2c() const;  // Easily accessible I2C reference
+
+		static const uint8_t I2C_Addr = 0x52;  // Address for all extension controllers
+		static const uint8_t ID_Size = 6;  // Number of bytes for ID signature
+
+	public:
+		/* I2C Communication Functions, Static & Shared */
+		static boolean initialize(NXC_I2C_TYPE& i2c);
+
+		static boolean writeRegister(NXC_I2C_TYPE& i2c, byte reg, byte value);
+		static boolean readRegister(NXC_I2C_TYPE& i2c, byte reg, uint8_t* dataOut);
+		static uint8_t readRegister(NXC_I2C_TYPE& i2c, byte reg);  // no error reporting
+
+		static boolean requestData(NXC_I2C_TYPE& i2c, uint8_t ptr, size_t size, uint8_t* dataOut);
+		static boolean requestControlData(NXC_I2C_TYPE& i2c, size_t size, uint8_t* controlData);
+		static boolean requestIdentity(NXC_I2C_TYPE& i2c, uint8_t* idData);
+
+		static ExtensionType identifyController(NXC_I2C_TYPE& i2c);
+
+		/* I2C Communication Functions, Inline Member */
+		inline boolean initialize() const { return initialize(data.i2c); }
+
+		inline boolean writeRegister(byte reg, byte value) const { return writeRegister(data.i2c, reg, value); }
+		inline boolean readRegister(byte reg, uint8_t* dataOut) const { return readRegister(data.i2c, reg, dataOut); }
+		inline uint8_t readRegister(byte reg) const { return readRegister(data.i2c, reg); }
+
+		inline boolean requestData(uint8_t ptr, size_t size, uint8_t* dataOut) const { return requestData(data.i2c, ptr, size, dataOut); }
+		inline boolean requestControlData(size_t size, uint8_t* controlData) const { return requestControlData(data.i2c, size, controlData); }
+		inline boolean requestIdentity(uint8_t* idData) const { return requestIdentity(data.i2c, idData); }
+
+		inline ExtensionType identifyController() const { return data.connectedType = identifyController(data.i2c); }
+
+	protected:
+		typedef NintendoExtensionCtrl::IndexMap  IndexMap;
+		typedef NintendoExtensionCtrl::ByteMap   ByteMap;
+		typedef NintendoExtensionCtrl::BitMap    BitMap;
+
+		uint8_t getControlData(const ByteMap map) const {
+			return (data.controlData[map.index] & map.mask) >> map.offset;
+		}
+
+		template<size_t size>
+		uint8_t getControlData(const ByteMap(&map)[size]) const {
+			uint8_t dataOut = 0x00;
+			for (size_t i = 0; i < size; i++) {
+				/* Repeated line from the single-ByteMap function above. Apparently the
+					constexpr stuff doesn't like being passed through nested functions. */
+				dataOut |= (data.controlData[map[i].index] & map[i].mask) >> map[i].offset;
+				//dataOut |= getControlData(map[i]);
+			}
+			return dataOut;
+		}
+
+		boolean getControlBit(const BitMap map) const {
+			return !(data.controlData[map.index] & (1 << map.position));  // Inverted logic, '0' is pressed
+		}
+
+		void setControlData(uint8_t index, uint8_t val);
+
+	private:
+		ExtensionData &data;  // I2C and shared connection data
+	};
+
 	// Simple struct to wrap the ExtensionData into an instance. This lets us inherit this wrapper
 	// to initialize the data before the inherited ExtensionController instance is initialized
 	struct ExtensionDataWrapper {
@@ -220,7 +222,8 @@ namespace NintendoExtensionCtrl {
 
 		using Shared = ExtensionPortVariant<ControllerMap>;
 	};
-}
+
+}  // End NintendoExtensionCtrl namespace
 
 // Public-facing version of the extension 'port' class that combines the 
 // communication (ExtensionController) with a data instance (ExtensionData), but omits

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -56,7 +56,8 @@ public:
 
 	void reset();
 
-	ExtensionType getControllerType() const;
+	virtual ExtensionType getControllerType() const;
+	ExtensionType getConnectedType() const;
 	boolean controllerTypeMatches() const;
 
 	uint8_t getControlData(uint8_t controlIndex) const;
@@ -69,8 +70,6 @@ public:
 	void printDebugID(Print& output = NXC_SERIAL_DEFAULT) const;
 	void printDebugRaw(Print& output = NXC_SERIAL_DEFAULT) const;
 	void printDebugRaw(uint8_t baseFormat, Print& output = NXC_SERIAL_DEFAULT) const;
-
-	const ExtensionType id = ExtensionType::AnyController;
 
 	static const uint8_t MinRequestSize = 6;   // Smallest reporting mode (0x37)
 	static const uint8_t MaxRequestSize = ExtensionData::ControlDataSize;
@@ -108,8 +107,6 @@ public:
 	inline ExtensionType identifyController() const { return data.connectedType = identifyController(data.i2c); }
 
 protected:
-	ExtensionController(ExtensionData& dataRef, ExtensionType conID);
-
 	typedef NintendoExtensionCtrl::IndexMap  IndexMap;
 	typedef NintendoExtensionCtrl::ByteMap   ByteMap;
 	typedef NintendoExtensionCtrl::BitMap    BitMap;

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -33,12 +33,12 @@ public:
 	struct ExtensionData {
 		friend class ExtensionController;
 
-		ExtensionData(NXC_I2C_TYPE& i2cbus = NXC_I2C_DEFAULT) :
+		ExtensionData(NXC_I2C_TYPE& i2cbus) :
 			i2c(i2cbus) {}
 
 		static const uint8_t ControlDataSize = 21;  // Largest reporting mode (0x3d)
 
-	protected:
+	private:
 		NXC_I2C_TYPE & i2c;  // Reference for the I2C (Wire) class
 		ExtensionType connectedType = ExtensionType::NoController;
 		uint8_t requestSize = MinRequestSize;

--- a/src/internal/ExtensionController.h
+++ b/src/internal/ExtensionController.h
@@ -139,22 +139,14 @@ private:
 
 namespace NintendoExtensionCtrl {
 	template <class ControllerMap>
-	class BuildControllerClass : public ControllerMap {
+	class BuildControllerClass : private ExtensionController::ExtensionData, public ControllerMap {
 	public:
 		BuildControllerClass(NXC_I2C_TYPE& i2cBus = NXC_I2C_DEFAULT) :
-			ControllerMap(portData),
-			portData(i2cBus) {}
+			ExtensionData(i2cBus),  // data instance
+			ControllerMap(static_cast<ExtensionData&>(*this))  // initialize ExtensionController instance with inherited ExtensionData
+		{}
 
 		using Shared = ControllerMap;  // Make controller class easily accessible
-
-	protected:
-		// Included data instance. Contains:
-		//    * I2C library object reference
-		//    * Connected controller identity (type)
-		//    * Control data array
-		// This data can be shared between controller instances using a single
-		// logical endpoint to keep memory down.
-		ExtensionController::ExtensionData portData;
 	};
 }
 

--- a/src/internal/NXC_Comms.h
+++ b/src/internal/NXC_Comms.h
@@ -20,8 +20,8 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NXC_Comms_h
-#define NXC_Comms_h
+#ifndef NXC_COMMS_H
+#define NXC_COMMS_H
 
 #include "Arduino.h"
 #include "NXC_Identity.h"

--- a/src/internal/NXC_DataMaps.h
+++ b/src/internal/NXC_DataMaps.h
@@ -20,8 +20,8 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NXC_DataMaps_h
-#define NXC_DataMaps_h
+#ifndef NXC_DATAMAPS_H
+#define NXC_DATAMAPS_H
 
 namespace NintendoExtensionCtrl {
 	// Map data alias for single byte data, using the full byte

--- a/src/internal/NXC_Identity.h
+++ b/src/internal/NXC_Identity.h
@@ -23,7 +23,7 @@
 #ifndef NXC_IDENTITY_H
 #define NXC_IDENTITY_H
 
-#include "Arduino.h"
+#include <stdint.h>
 
 enum class ExtensionType {
 	NoController,

--- a/src/internal/NXC_Identity.h
+++ b/src/internal/NXC_Identity.h
@@ -20,8 +20,8 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NXC_Identity_h
-#define NXC_Identity_h
+#ifndef NXC_IDENTITY_H
+#define NXC_IDENTITY_H
 
 #include "Arduino.h"
 

--- a/src/internal/NXC_LinkedList.cpp
+++ b/src/internal/NXC_LinkedList.cpp
@@ -1,0 +1,83 @@
+/*
+*  Project     Nintendo Extension Controller Library
+*  @author     David Madison
+*  @link       github.com/dmadison/NintendoExtensionCtrl
+*  @license    LGPLv3 - Copyright (c) 2021 David Madison
+*
+*  This file is part of the Nintendo Extension Controller Library.
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Lesser General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Lesser General Public License for more details.
+*
+*  You should have received a copy of the GNU Lesser General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "NXC_LinkedList.h"
+
+namespace NintendoExtensionCtrl {
+
+void ExtensionList::add(Node* node) {
+	if (head == nullptr) {
+		head = node;
+	}
+	else {
+		Node* last = head;
+		while (true) {
+			if (last->next == nullptr) break;  // found last entry
+			last = last->next;
+		}
+		last->next = node;
+	}
+}
+
+void ExtensionList::remove(Node* node) {
+	if (node == head) {
+		head = node->next; // Set head to next, and we're done
+		return;
+	}
+
+	// Otherwise we're somewhere else in the list. Iterate through to find it.
+	Node* ptr = head;
+
+	while (ptr != nullptr) {
+		if (ptr->next == node) {  // FOUND!
+			ptr->next = node->next;  // Set the previous "next" as this entry's "next" (skip this object)
+			break;  // Stop searching
+		}
+		ptr = ptr->next;  // Not found. Next entry...
+	}
+}
+
+ExtensionList::Node* ExtensionList::getHead() const {
+	return head;
+}
+
+
+ExtensionList::Node::Node(ExtensionList& l, ExtensionController& ctrl)
+	: controller(ctrl), list(l)
+{
+	list.add(this);
+}
+
+ExtensionList::Node::~Node()
+{
+	list.remove(this);
+}
+
+ExtensionController& ExtensionList::Node::getController() const {
+	return controller;
+}
+
+ExtensionList::Node* ExtensionList::Node::getNext() const {
+	return next;
+}
+
+}  // End "NintendoExtensionCtrl" namespace

--- a/src/internal/NXC_LinkedList.h
+++ b/src/internal/NXC_LinkedList.h
@@ -1,0 +1,61 @@
+/*
+*  Project     Nintendo Extension Controller Library
+*  @author     David Madison
+*  @link       github.com/dmadison/NintendoExtensionCtrl
+*  @license    LGPLv3 - Copyright (c) 2021 David Madison
+*
+*  This file is part of the Nintendo Extension Controller Library.
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Lesser General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Lesser General Public License for more details.
+*
+*  You should have received a copy of the GNU Lesser General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NXC_LINKED_LIST_H
+#define NXC_LINKED_LIST_H
+
+
+class ExtensionController;
+
+namespace NintendoExtensionCtrl {
+	class ExtensionList {
+	public:
+		class Node {
+		public:
+			friend class ExtensionList;  // for changing next ptr
+
+			Node(ExtensionList&, ExtensionController&);
+			~Node();
+
+			ExtensionController& getController() const;
+			Node* getNext() const;
+
+		private:
+			ExtensionController& controller;
+
+			ExtensionList& list;
+			Node* next = nullptr;
+		};
+		friend Node::Node(ExtensionList&, ExtensionController&), Node::~Node();  // for add/remove access
+
+		Node* getHead() const;
+
+	protected:
+		void add(Node* node);
+		void remove(Node* node);
+
+	private:
+		Node* head = nullptr;
+	};
+}
+
+#endif

--- a/src/internal/NXC_LinkedList.h
+++ b/src/internal/NXC_LinkedList.h
@@ -24,9 +24,9 @@
 #define NXC_LINKED_LIST_H
 
 
-class ExtensionController;
-
 namespace NintendoExtensionCtrl {
+	class ExtensionController;
+
 	class ExtensionList {
 	public:
 		class Node {

--- a/src/internal/NXC_Utils.h
+++ b/src/internal/NXC_Utils.h
@@ -20,8 +20,8 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef NXC_Core_h
-#define NXC_Core_h
+#ifndef NXC_UTILS_H
+#define NXC_UTILS_H
 
 #include "NXC_Comms.h"
 


### PR DESCRIPTION
The main goal of this change was to improve the way the library handles multiple controller types within the same program.

The complication is `specificInit`, as some of the controllers now require different initialization than others. This is dependent on which specific controllers are used though, so users had to create a list of `ExtensionController` pointers and then iterate through them, checking if both the type matched and if the `specificInit` call succeeded. Needless to say, this is messy...

The solution in this PR is a linked list, included as part of the `ExtensionPort` class and with nodes added to each `::Shared` instance. This allows the `ExtensionPort` class to elegantly handle connections without any special user input regardless of which controllers are defined. Having a list available will also allow the class to handle other controller-specific communication quirks moving forward.

Making this possible required some backend changes, including making the controller identity filtering now use a virtual function (`getExpectedType`). I also created a set of nested class templates to build up the public-facing instances of each variant without having to redefine the constructors and attributes in each derived class. This also logically separates the base controller maps, the public facing instance with bundled data, and the publicly facing instance with shared data and a linked list node. Now that they're defined separately these will be easier to modify and extend moving forward.

This PR also includes some miscellaneous backend changes:
* Potential initialization order issue for extension data should now be fixed, using a multiple inheritance model
* Derived controller classes no longer define their own constructors (where possible)
* `_Shared` classes are now `Base`, as they lack the 'shared' list node assembled elsewhere
* `ExtensionController` is no longer in the public namespace, as it was supplanted by `ExtensionPort` circa 0.7.1.
* Include guards are now capitalized to indicate that they're preprocessor constants.